### PR TITLE
Updating Dynamic Cluster & Static Cluster to be Reference Types,

### DIFF
--- a/clusterMembership/dynamicCluster.go
+++ b/clusterMembership/dynamicCluster.go
@@ -5,51 +5,52 @@ package cluster_membership
  * Keeps a Map of the nodeId to Node for fast lookup of nodes.
  */
 type dynamicCluster struct {
-	members map[string]Node
+	membersList []Node
 }
 
 /*
  * Returns a Snapshot of the Cluster Membership state
  */
-func (c dynamicCluster) Members() []Node {
-
-	nodes := make([]Node, len(c.members))
-	index := 0
-
-	for _, n := range c.members {
-		nodes[index] = n
-		index++
-	}
-
-	return nodes
+func (c *dynamicCluster) Members() []Node {
+	return c.membersList
 }
 
 /*
  * Adds A Node from the Cluster
  */
-func (c dynamicCluster) AddNode(n Node) {
-	c.members[n.Id()] = n
+func (c *dynamicCluster) AddNode(n Node) {
+	c.membersList = append(c.membersList, n)
 }
 
 /*
  * Permanently Removes A Node from the Cluster
  */
-func (c dynamicCluster) RemoveNode(nodeId string) {
-	delete(c.members, nodeId)
+func (c *dynamicCluster) RemoveNode(nodeId string) {
+	var indexToDelete int = -1
+	for i, node := range c.membersList {
+		if node.Id() == nodeId {
+			indexToDelete = i
+			break
+		}
+	}
+
+	if indexToDelete >= 0 {
+		c.membersList, c.membersList[len(c.membersList)-1] = append(c.membersList[:indexToDelete], c.membersList[indexToDelete+1:]...), nil
+	}
 }
 
 /*
  * Creates a Dynamic Cluster with the an initial list of nodes
  * Dynamic Cluster can be moodified by adding or removing nodes.
  */
-func DynamicClusterFactory(initialNodes []Node) dynamicCluster {
-	membersMap := make(map[string]Node)
+func DynamicClusterFactory(initialNodes []Node) *dynamicCluster {
+	var membersList []Node
 
 	for _, node := range initialNodes {
-		membersMap[node.Id()] = node
+		membersList = append(membersList, node)
 	}
 
-	return dynamicCluster{
-		members: membersMap,
+	return &dynamicCluster{
+		membersList: membersList,
 	}
 }

--- a/clusterMembership/staticCluster.go
+++ b/clusterMembership/staticCluster.go
@@ -11,7 +11,7 @@ type staticCluster struct {
 	members []Node
 }
 
-func (c staticCluster) Members() []Node {
+func (c *staticCluster) Members() []Node {
 	return c.members
 }
 
@@ -19,8 +19,8 @@ func (c staticCluster) Members() []Node {
  * Creates a Static Cluster with the specified nodes.  Once
  * Defined the list of nodes in a static cluster can never be changed
  */
-func StaticClusterFactory(nodes []Node) staticCluster {
-	return staticCluster{
+func StaticClusterFactory(nodes []Node) *staticCluster {
+	return &staticCluster{
 		members: nodes,
 	}
 }


### PR DESCRIPTION
Updating Dynamic Cluster to store pre-calculated members slice for faster Members() response
Dynamic Cluster remove internal map, no longer needed for fast lookup since sendMessage was removed from Interface