### PR TITLE
Add Build Dependencies to MakeFile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.6
 
 before_install:
-  - go get -t $(go list ./...)
+  - make dependencies
   
 before_script:
   - go fmt ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ go:
   - 1.6
 
 before_install:
-  - go get github.com/golang/mock/gomock
-  - go get github.com/golang/mock/mockgen
-  - go get github.com/onsi/gomega
-  - go get github.com/onsi/ginkgo
-  - go get golang.org/x/tools/cmd/cover
+  - make dependencies
   
 before_script:
   - go fmt ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.6
 
 before_install:
-  - make dependencies
+  - go get -t $(go list ./...)
   
 before_script:
   - go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,14 @@ default:
 	go build ./...
 
 dependencies: 
-	go get -t $(go list ./...)
+	go get github.com/golang/mock/gomock
+	go get github.com/golang/mock/mockgen
+	go get github.com/onsi/gomega
+	go get github.com/onsi/ginkgo
+	go get github.com/spf13/cobra
+	go get golang.org/x/net/context
+	go get golang.org/x/tools/cmd/cover
+	go get google.golang.org/grpc
 
 test: 
 	go generate ./...

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ default:
 	go build ./...
 
 dependencies: 
-	go get github.com/onsi/gomega
-	go get github.com/onsi/ginkgo
 	go get github.com/golang/mock/gomock
 	go get github.com/golang/mock/mockgen
+	go get github.com/onsi/gomega
+	go get github.com/onsi/ginkgo
+	go get github.com/spf13/cobra
 	go get golang.org/x/net/context
 	go get golang.org/x/tools/cmd/cover
 	go get google.golang.org/grpc

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ PROJECT_URL := "https://github.com/scootdev/scoot"
 default: 
 	go build ./...
 
+dependencies: 
+	go get github.com/onsi/gomega
+	go get github.com/onsi/ginkgo
+	go get github.com/golang/mock/gomock
+	go get github.com/golang/mock/mockgen
+	go get golang.org/x/net/context
+	go get golang.org/x/tools/cmd/cover
+	go get google.golang.org/grpc
+
 test: 
 	go generate ./...
 	go test -v -race $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ default:
 
 dependencies: 
 	go get -t github.com/scootdev/scoot/...
-	
+
+	# mockgen is only referenced for code gen, not imported directly
+	go get github.com/golang/mock/mockgen 
+
 test: 
 	go generate ./...
 	go test -v -race $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,8 @@ default:
 	go build ./...
 
 dependencies: 
-	go get github.com/golang/mock/gomock
-	go get github.com/golang/mock/mockgen
-	go get github.com/onsi/gomega
-	go get github.com/onsi/ginkgo
-	go get github.com/spf13/cobra
-	go get golang.org/x/net/context
-	go get golang.org/x/tools/cmd/cover
-	go get google.golang.org/grpc
-
+	go get -t github.com/scootdev/scoot/...
+	
 test: 
 	go generate ./...
 	go test -v -race $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,7 @@ default:
 	go build ./...
 
 dependencies: 
-	go get github.com/golang/mock/gomock
-	go get github.com/golang/mock/mockgen
-	go get github.com/onsi/gomega
-	go get github.com/onsi/ginkgo
-	go get github.com/spf13/cobra
-	go get golang.org/x/net/context
-	go get golang.org/x/tools/cmd/cover
-	go get google.golang.org/grpc
+	go get -t $(go list ./...)
 
 test: 
 	go generate ./...


### PR DESCRIPTION
Adding dependencies command to make file.  Using this command to install all dependencies needed for TravisCI build.

The goal is to :
- make it it easy to setup dev environment
- make it easy to sync dependencies when new ones are added
- ensure our build process & dev environment are similar