### PR TITLE
Caitie/make dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ default:
 	go build ./...
 
 dependencies: 
+	# get all dependencies needed to run scoot / check if there have
+	# been updates since they were first installed
 	go get -t -u github.com/scootdev/scoot/...
 
 	# mockgen is only referenced for code gen, not imported directly

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dependencies:
 	go get -t -u github.com/scootdev/scoot/...
 
 	# mockgen is only referenced for code gen, not imported directly
-	go get github.com/golang/mock/mockgen
+	go get -u github.com/golang/mock/mockgen
 
 generate: 
 	go generate ./...
@@ -30,3 +30,5 @@ clean-mockgen:
 
 clean: clean-mockgen
 	go clean ./...
+
+fullbuild: dependencies generate test

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,23 @@ PROJECT_URL := "https://github.com/scootdev/scoot"
 default:
 	go build ./...
 
+dependencies: 
+	go get -t -u github.com/scootdev/scoot/...
+
+	# mockgen is only referenced for code gen, not imported directly
+	go get github.com/golang/mock/mockgen
+
+generate: 
+	go generate ./...
+
 test:
 	go test -v -race $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 	sh testCoverage.sh
 
-clean:
+testlocal: generate test
+
+clean-mockgen:
+	rm */*_mock.go
+
+clean: clean-mockgen
 	go clean ./...


### PR DESCRIPTION
Adding local commands back to makefile.  These are useful for running & testing locally, and for quickly getting setup with scoot as defined on go/scootdev