### PR TITLE
adding specific errors to saga log

### DIFF
--- a/saga/sagaState.go
+++ b/saga/sagaState.go
@@ -332,7 +332,7 @@ func updateSagaState(s *SagaState, msg sagaMessage) (*SagaState, error) {
 
 		// All EndTask Messages must have a preceding StartTask Message
 		if !state.IsTaskStarted(msg.taskId) {
-			return nil, NewInvalidSagaStateError(fmt.Sprintf("Cannot have a EndTask Message Before a StartTask Message, taskId: ", msg.taskId))
+			return nil, NewInvalidSagaStateError(fmt.Sprintf("Cannot have a EndTask Message Before a StartTask Message, taskId: %s", msg.taskId))
 		}
 
 		state.taskState[msg.taskId] = state.taskState[msg.taskId] | TaskCompleted

--- a/saga/sagaState_prop_test.go
+++ b/saga/sagaState_prop_test.go
@@ -52,11 +52,14 @@ func Test_ValidateUpdateSagaState(t *testing.T) {
 				}
 			}
 
+			// validate the correct error is returned
+			_, sErrorOk := err.(InvalidSagaStateError)
+
 			// either we made a valid transition and had a valid update or applying
 			// this message is an invalidTransition and an error was returned.
 			validUpdate := validTransition && err == nil &&
 				newState != nil && newState.IsSagaCompleted()
-			errorReturned := !validTransition && err != nil && newState == nil
+			errorReturned := !validTransition && err != nil && sErrorOk && newState == nil
 
 			return validUpdate || errorReturned
 		},
@@ -71,11 +74,14 @@ func Test_ValidateUpdateSagaState(t *testing.T) {
 			msg := MakeAbortSagaMessage(state.SagaId())
 			newState, err := updateSagaState(state, msg)
 
+			// validate the correct error is returned
+			_, sErrorOk := err.(InvalidSagaStateError)
+
 			// either we made a valid transition and had a valid update or applying
 			// this message is an invalidTransition and an error was returned.
 			validUpdate := validTransition && err == nil &&
 				newState != nil && newState.IsSagaAborted()
-			errorReturned := !validTransition && err != nil && newState == nil
+			errorReturned := !validTransition && err != nil && sErrorOk && newState == nil
 
 			return validUpdate || errorReturned
 		},
@@ -95,12 +101,15 @@ func Test_ValidateUpdateSagaState(t *testing.T) {
 			msg := MakeStartTaskMessage(state.SagaId(), taskId, data)
 			newState, err := updateSagaState(state, msg)
 
+			// validate the correct error is returned
+			_, sErrorOk := err.(InvalidSagaStateError)
+
 			// either we made a valid transition and had a valid update or applying
 			// this message is an invalidTransition and an error was returned.
 			validUpdate := validTransition && err == nil &&
 				newState != nil && newState.IsTaskStarted(taskId) &&
 				bytes.Equal(newState.GetStartTaskData(taskId), data)
-			errorReturned := !validTransition && err != nil && newState == nil
+			errorReturned := !validTransition && err != nil && sErrorOk && newState == nil
 
 			return validUpdate || errorReturned
 		},
@@ -122,12 +131,15 @@ func Test_ValidateUpdateSagaState(t *testing.T) {
 			msg := MakeEndTaskMessage(state.SagaId(), taskId, data)
 			newState, err := updateSagaState(state, msg)
 
+			// validate the correct error is returned
+			_, sErrorOk := err.(InvalidSagaStateError)
+
 			// either we made a valid transition and had a valid update or applying
 			// this message is an invalidTransition and an error was returned.
 			validUpdate := validTransition && err == nil &&
 				newState != nil && newState.IsTaskCompleted(taskId) &&
 				bytes.Equal(newState.GetEndTaskData(taskId), data)
-			errorReturned := !validTransition && err != nil && newState == nil
+			errorReturned := !validTransition && err != nil && sErrorOk && newState == nil
 
 			return validUpdate || errorReturned
 		},
@@ -147,12 +159,15 @@ func Test_ValidateUpdateSagaState(t *testing.T) {
 			msg := MakeStartCompTaskMessage(state.SagaId(), taskId, data)
 			newState, err := updateSagaState(state, msg)
 
+			// validate the correct error is returned
+			_, sErrorOk := err.(InvalidSagaStateError)
+
 			// either we made a valid transition and had a valid update or applying
 			// this message is an invalidTransition and an error was returned.
 			validUpdate := validTransition && err == nil &&
 				newState != nil && newState.IsCompTaskStarted(taskId) &&
 				bytes.Equal(newState.GetStartCompTaskData(taskId), data)
-			errorReturned := !validTransition && err != nil && newState == nil
+			errorReturned := !validTransition && err != nil && sErrorOk && newState == nil
 
 			return validUpdate || errorReturned
 		},
@@ -172,12 +187,15 @@ func Test_ValidateUpdateSagaState(t *testing.T) {
 			msg := MakeEndCompTaskMessage(state.SagaId(), taskId, data)
 			newState, err := updateSagaState(state, msg)
 
+			// validate the correct error is returned
+			_, sErrorOk := err.(InvalidSagaStateError)
+
 			// either we made a valid transition and had a valid update or applying
 			// this message is an invalidTransition and an error was returned.
 			validUpdate := validTransition && err == nil &&
 				newState != nil && newState.IsCompTaskCompleted(taskId) &&
 				bytes.Equal(newState.GetEndCompTaskData(taskId), data)
-			errorReturned := !validTransition && err != nil && newState == nil
+			errorReturned := !validTransition && err != nil && sErrorOk && newState == nil
 
 			return validUpdate || errorReturned
 		},

--- a/saga/sagaState_test.go
+++ b/saga/sagaState_test.go
@@ -24,7 +24,13 @@ func TestsagaStateFactory(t *testing.T) {
 func TestSagaState_ValidateSagaId(t *testing.T) {
 	err := validateSagaId("")
 	if err == nil {
-		t.Error(fmt.Sprintf("Invalid Saga Id Should Return Error"))
+		t.Error("Invalid Saga Id Should Return Error")
+	}
+
+	// validate the correct error is returned
+	_, sErrorOk := err.(InvalidSagaMessageError)
+	if !sErrorOk {
+		t.Error("Expected Returned Error to be InvalidSagaMessageError")
 	}
 }
 
@@ -32,6 +38,12 @@ func TestSagaState_ValidateTaskId(t *testing.T) {
 	err := validateTaskId("")
 	if err == nil {
 		t.Error(fmt.Sprintf("Invalid Task Id Should Return Error"))
+	}
+
+	// validate the correct error is returned
+	_, sErrorOk := err.(InvalidSagaMessageError)
+	if !sErrorOk {
+		t.Error("Expected Returned Error to be InvalidSagaMessageError")
 	}
 }
 

--- a/saga/sagalog.go
+++ b/saga/sagalog.go
@@ -33,3 +33,37 @@ type SagaLog interface {
 	 */
 	GetActiveSagas() ([]string, error)
 }
+
+// InvalidRequestError should be returned by the SagaLog
+// when the request is invalid and the same request will
+// fail on restart, equivalent to an HTTP 400
+type InvalidRequestError struct {
+	s string
+}
+
+func (e InvalidRequestError) Error() string {
+	return e.s
+}
+
+func NewInvalidRequeustError(msg string) error {
+	return InvalidRequestError{
+		s: msg,
+	}
+}
+
+// InternalLogError should be returned by the SagaLog
+// when the request failed, but may succeed on retry
+// this is equivalent to an HTTP 500
+type InternalLogError struct {
+	s string
+}
+
+func (e InternalLogError) Error() string {
+	return e.s
+}
+
+func NewInternalLogError(msg string) error {
+	return InternalLogError{
+		s: msg,
+	}
+}


### PR DESCRIPTION
Callers need to be able to distinguish between error types, so they know if its transient error i.e. log writes temporarily unavailable or illegal state update.  Test cases updated to check for specific error

Also practicing what I preach In [Simple Test Cases Can Prevent Most Critical Failures](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-yuan.pdf) one of the big discoveries that aborting on overly generic errors / poor error handling resulted in many catastrophic failures in distributed systems. 