### PR TITLE
snapshots: Checkouter; the first piece of Filer

### DIFF
--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/scootdev/scoot/daemon/server"
 	"github.com/scootdev/scoot/runner/execer"
 	"github.com/scootdev/scoot/runner/execer/fake"
 	"github.com/scootdev/scoot/runner/execer/os"
 	"github.com/scootdev/scoot/runner/local"
-	"log"
+	fakesnaps "github.com/scootdev/scoot/snapshots/fake"
 )
 
 var execerType = flag.String("execer_type", "sim", "execer type; os or sim")
@@ -24,7 +26,7 @@ func main() {
 	default:
 		log.Fatalf("Unknown execer type %v", *execerType)
 	}
-	r := local.NewSimpleRunner(ex)
+	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter())
 	s, err := server.NewServer(r)
 	if err != nil {
 		log.Fatal("Cannot create Scoot server: ", err)

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/runner/execer/fake"
 	localrunner "github.com/scootdev/scoot/runner/local"
+	fakesnaps "github.com/scootdev/scoot/snapshots/fake"
 	"github.com/scootdev/scoot/workerapi/server"
 )
 
@@ -29,7 +30,7 @@ func main() {
 	transportFactory := thrift.NewTTransportFactory()
 
 	stats := stat.Scope("workerserver")
-	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil))
+	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil), fakesnaps.MakeInvalidCheckouter())
 	version := func() string { return "" }
 	handler := server.NewHandler(stats, run, version)
 	err := server.Serve(handler, fmt.Sprintf("localhost:%d", *thriftPort), transportFactory, protocolFactory)

--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -6,7 +6,7 @@ package execer
 
 type Command struct {
 	Argv []string
-	// TODO(dbentley): accept dir
+	Dir  string
 	// TODO(dbentley): environment variables?
 }
 

--- a/runner/execer/fake/sim.go
+++ b/runner/execer/fake/sim.go
@@ -91,9 +91,10 @@ func (p *simProcess) Wait() execer.ProcessStatus {
 	return p.status
 }
 
-//Abort op not supported by sim.
 func (p *simProcess) Abort() execer.ProcessStatus {
-	panic("Abort not implemented in sim code.")
+	st := execer.ProcessStatus{State: execer.FAILED}
+	p.setStatus(st)
+	return st
 }
 
 func (p *simProcess) setStatus(status execer.ProcessStatus) {

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -132,7 +132,7 @@ func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, cancelCh cha
 	case <-checkoutDone:
 	}
 	if err != nil {
-		r.updateStatus(runner.FailedStatus(runId, fmt.Errorf("could not checkout: %v", err)))
+		r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("could not checkout: %v", err)))
 		return
 	}
 	defer checkout.Release()
@@ -142,7 +142,7 @@ func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, cancelCh cha
 		Dir:  checkout.Path(),
 	})
 	if err != nil {
-		r.updateStatus(runner.FailedStatus(runId, fmt.Errorf("could not exec: %v", err)))
+		r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("could not exec: %v", err)))
 		return
 	}
 

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -7,23 +7,30 @@ import (
 
 	"github.com/scootdev/scoot/runner"
 	"github.com/scootdev/scoot/runner/execer"
+	"github.com/scootdev/scoot/snapshots"
 )
 
-func NewSimpleRunner(exec execer.Execer) runner.Runner {
-	r := &simpleRunner{}
-	r.exec = exec
-	r.runs = make(map[runner.RunId]runner.ProcessStatus)
-	r.running = make(map[runner.RunId]execer.Process)
-	return r
+func NewSimpleRunner(exec execer.Execer, checkouter snapshots.Checkouter) runner.Runner {
+	return &simpleRunner{
+		exec:       exec,
+		checkouter: checkouter,
+		runs:       make(map[runner.RunId]runner.ProcessStatus),
+	}
 }
 
-// simpleRunner runs N=maxRunning processes at a time and stores results.
+// simpleRunner runs one process at a time and stores results.
 type simpleRunner struct {
-	exec      execer.Execer
-	runs      map[runner.RunId]runner.ProcessStatus
-	running   map[runner.RunId]execer.Process
-	nextRunId int64
-	mu        sync.Mutex
+	exec       execer.Execer
+	checkouter snapshots.Checkouter
+	runs       map[runner.RunId]runner.ProcessStatus
+	running    *inflight
+	nextRunId  int64
+	mu         sync.Mutex
+}
+
+type inflight struct {
+	runId    runner.RunId
+	cancelCh chan struct{}
 }
 
 func (r *simpleRunner) Run(cmd *runner.Command) runner.ProcessStatus {
@@ -32,24 +39,31 @@ func (r *simpleRunner) Run(cmd *runner.Command) runner.ProcessStatus {
 	runId := runner.RunId(fmt.Sprintf("%d", r.nextRunId))
 	r.nextRunId++
 
-	if len(r.running) == 1 {
+	if r.running != nil {
 		r.runs[runId] = runner.BadRequestStatus(runId, fmt.Errorf("Runner is busy"))
 		return r.runs[runId]
 	}
 
-	var c execer.Command
-	c.Argv = cmd.Argv
-	p, err := r.exec.Exec(c)
-	if err != nil {
-		r.runs[runId] = runner.BadRequestStatus(runId, fmt.Errorf("could not exec: %v", err))
-		return r.runs[runId]
+	r.running = &inflight{runId: runId, cancelCh: make(chan struct{})}
+	r.runs[runId] = runner.PreparingStatus(runId)
+
+	// Run in a new goroutine
+	go r.run(cmd, runId, r.running.cancelCh)
+	if cmd.Timeout > 0 { // Timeout if applicable
+		time.AfterFunc(cmd.Timeout, func() { r.updateStatus(runner.TimeoutStatus(runId)) })
 	}
-	r.runs[runId] = runner.RunningStatus(runId)
-	r.running[runId] = p
-
-	go babysit(p, runId, r, cmd.Timeout)
-
+	// TODO(dbentley): we return PREPARING now to defend against long-checkout
+	// But we could sleep short (50ms?), query status, and return that to capture the common, fast case
 	return r.runs[runId]
+}
+
+func makeRunnerStatus(st execer.ProcessStatus, runId runner.RunId) runner.ProcessStatus {
+	if st.State == execer.COMPLETE {
+		return runner.CompleteStatus(runId, st.StdoutURI, st.StderrURI, st.ExitCode)
+	} else if st.State == execer.FAILED {
+		return runner.ErrorStatus(runId, fmt.Errorf("error execing: %v", st.Error))
+	}
+	return runner.ErrorStatus(runId, fmt.Errorf("unexpected exec state: %v", st.State))
 }
 
 func (r *simpleRunner) Status(run runner.RunId) runner.ProcessStatus {
@@ -73,7 +87,7 @@ func (r *simpleRunner) StatusAll() []runner.ProcessStatus {
 }
 
 func (r *simpleRunner) Abort(run runner.RunId) runner.ProcessStatus {
-	return r.abortImpl(run, runner.ABORTED)
+	return r.updateStatus(runner.AbortStatus(run))
 }
 
 func (r *simpleRunner) Erase(run runner.RunId) {
@@ -85,52 +99,64 @@ func (r *simpleRunner) Erase(run runner.RunId) {
 	}
 }
 
-func (r *simpleRunner) abortImpl(run runner.RunId, state runner.ProcessState) runner.ProcessStatus {
+func (r *simpleRunner) updateStatus(new runner.ProcessStatus) runner.ProcessStatus {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	result, ok := r.running[run]
+	old, ok := r.runs[new.RunId]
 	if !ok {
-		return runner.BadRequestStatus(run, fmt.Errorf("could not find abortable run: %v", run))
+		return runner.BadRequestStatus(new.RunId, fmt.Errorf("cannot find run %v", new.RunId))
 	}
-	result.Abort()
-	delete(r.running, run)
-	r.runs[run] = runner.AbortStatus(run)
-	return r.runs[run]
+	if old.State.IsDone() {
+		return old
+	}
+	r.runs[new.RunId] = new
+	if new.State.IsDone() && r.running.runId == new.RunId {
+		close(r.running.cancelCh)
+		r.running = nil
+	}
+	return new
 }
 
-func babysit(p execer.Process, run runner.RunId, r *simpleRunner, timeout time.Duration) {
-	done := make(chan interface{})
-	if timeout > 0 {
-		go func() {
-			select {
-			case <-time.NewTimer(timeout).C:
-				r.abortImpl(run, runner.TIMEDOUT)
-			case <-done:
-				return
-			}
-		}()
+// run cmd in the background, writing results to r as id, unless cancelCh is closed
+func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, cancelCh chan struct{}) {
+	checkout, err, checkoutDone := (snapshots.Checkout)(nil), (error)(nil), make(chan struct{}, 1)
+	go func() {
+		checkout, err = r.checkouter.Checkout(cmd.SnapshotId)
+		close(checkoutDone)
+	}()
+
+	// Wait for checkout or cancel
+	select {
+	case <-cancelCh:
+		return
+	case <-checkoutDone:
 	}
-
-	status := p.Wait()
-	if timeout > 0 {
-		done <- nil
+	if err != nil {
+		r.updateStatus(runner.FailedStatus(runId, fmt.Errorf("could not checkout: %v", err)))
+		return
 	}
+	defer checkout.Release()
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.running, run)
-
-	// Check if we already marked this run as done (i.e. in Abort())
-	if r.runs[run].State.IsDone() {
+	p, err := r.exec.Exec(execer.Command{
+		Argv: cmd.Argv,
+		Dir:  checkout.Path(),
+	})
+	if err != nil {
+		r.updateStatus(runner.FailedStatus(runId, fmt.Errorf("could not exec: %v", err)))
 		return
 	}
 
-	switch status.State {
-	case execer.COMPLETE:
-		r.runs[run] = runner.CompleteStatus(run, status.StdoutURI, status.StderrURI, status.ExitCode)
-	case execer.FAILED:
-		r.runs[run] = runner.ErrorStatus(run, fmt.Errorf("error execing: %v", status.Error))
-	default:
-		r.runs[run] = runner.ErrorStatus(run, fmt.Errorf("unexpected exec state: %v", status.State))
+	r.updateStatus(runner.RunningStatus(runId))
+
+	processCh := make(chan execer.ProcessStatus, 1)
+	go func() { processCh <- p.Wait() }()
+
+	// Wait for process complete or cancel
+	select {
+	case <-cancelCh:
+		p.Abort()
+		return
+	case st := <-processCh:
+		r.updateStatus(makeRunnerStatus(st, runId))
 	}
 }

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -110,7 +110,10 @@ func (r *simpleRunner) updateStatus(new runner.ProcessStatus) runner.ProcessStat
 		return old
 	}
 	r.runs[new.RunId] = new
-	if new.State.IsDone() && r.running.runId == new.RunId {
+	if new.State.IsDone() {
+		// We are ending the running task.
+		// depend on the invariant that there is at most 1 run with !state.IsDone(),
+		// so if we're changing a Process from not Done to Done it must be running
 		close(r.running.cancelCh)
 		r.running = nil
 	}

--- a/runner/local/simple_test.go
+++ b/runner/local/simple_test.go
@@ -51,7 +51,7 @@ func TestAbort(t *testing.T) {
 	runId := run(t, r, args)
 	assertWait(t, r, runId, running(), args...)
 	r.Abort(runId)
-	// use r.Status isntead of assertWait so that we make sure it's aborted immediately, not eventually
+	// use r.Status instead of assertWait so that we make sure it's aborted immediately, not eventually
 	st := r.Status(runId)
 	assertStatus(t, st, aborted(), args...)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -13,6 +13,8 @@ const (
 	UNKNOWN ProcessState = iota
 	// Waiting to run.
 	PENDING
+	// Preparing to run (e.g., checking out the Snapshot)
+	PREPARING
 	// Running
 	RUNNING
 
@@ -32,7 +34,7 @@ const (
 )
 
 func (p ProcessState) IsDone() bool {
-	return p == UNKNOWN || p == COMPLETE || p == FAILED || p == ABORTED || p == TIMEDOUT
+	return p == COMPLETE || p == FAILED || p == ABORTED || p == TIMEDOUT
 }
 
 func (p ProcessState) String() string {
@@ -41,6 +43,8 @@ func (p ProcessState) String() string {
 		return "UNKNOWN"
 	case PENDING:
 		return "PENDING"
+	case PREPARING:
+		return "PREPARING"
 	case RUNNING:
 		return "RUNNING"
 	case COMPLETE:

--- a/runner/status.go
+++ b/runner/status.go
@@ -49,11 +49,3 @@ func PreparingStatus(runId RunId) (r ProcessStatus) {
 		State: PREPARING,
 	}
 }
-
-func FailedStatus(runId RunId, err error) (r ProcessStatus) {
-	return ProcessStatus{
-		RunId: runId,
-		State: FAILED,
-		Error: err.Error(),
-	}
-}

--- a/runner/status.go
+++ b/runner/status.go
@@ -42,3 +42,18 @@ func CompleteStatus(runId RunId, stdoutRef string, stderrRef string, exitCode in
 	r.ExitCode = exitCode
 	return r
 }
+
+func PreparingStatus(runId RunId) (r ProcessStatus) {
+	return ProcessStatus{
+		RunId: runId,
+		State: PREPARING,
+	}
+}
+
+func FailedStatus(runId RunId, err error) (r ProcessStatus) {
+	return ProcessStatus{
+		RunId: runId,
+		State: FAILED,
+		Error: err.Error(),
+	}
+}

--- a/snapshots/fake/fake_filer.go
+++ b/snapshots/fake/fake_filer.go
@@ -1,0 +1,37 @@
+package fake
+
+import (
+	"github.com/scootdev/scoot/snapshots"
+)
+
+func MakeInvalidCheckouter() snapshots.Checkouter {
+	return &noopCheckouter{path: "/path/is/invalid"}
+}
+
+type noopCheckouter struct {
+	path string
+}
+
+func (c *noopCheckouter) Checkout(id string) (snapshots.Checkout, error) {
+	return &staticCheckout{
+		path: c.path,
+		id:   id,
+	}, nil
+}
+
+type staticCheckout struct {
+	path string
+	id   string
+}
+
+func (c *staticCheckout) Path() string {
+	return c.path
+}
+
+func (c *staticCheckout) ID() string {
+	return c.id
+}
+
+func (c *staticCheckout) Release() error {
+	return nil
+}

--- a/snapshots/filer.go
+++ b/snapshots/filer.go
@@ -1,0 +1,31 @@
+package snapshots
+
+// A Snapshot is a low-level interface offering per-file access to data in a Snapshot.
+// This is useful for tools that want one file at a time, or for ScootFS to offer the data.
+// Many tools want a higher-level construct: a Filer.
+// A Filer lets clients deal with Snapshots as files in the local filesystem.
+type Filer interface {
+	Checkouter
+	// TODO(dbentley): support ingestion
+	// Ingester
+}
+
+// Checkouter allows reading a Snapshot into the local filesystem.
+type Checkouter interface {
+	// Checkout checks out the Snapshot identified by id, or an error if it fails.
+	Checkout(id string) (Checkout, error)
+}
+
+// Checkout represents one checkout of a Snapshot.
+// A Checkout is a copy of a Snapshot that lives in the local filesystem at a path.
+type Checkout interface {
+	// Path in the local filesystem to the Checkout
+	Path() string
+
+	// ID of the checked-out Snapshot
+	ID() string
+
+	// Releases this Checkout, allowing the Checkouter to clean/recycle this checkout.
+	// After Release(), the client may not look at files under Path()
+	Release() error
+}


### PR DESCRIPTION
Filer offers high-level interaction with Snapshots. Checkout a Snapshot into the
local filesystem, or Ingest the local filesystem into a Snapshot. (For now we
only offer Checkout).

Use this abstraction in Runner and extend the Execer interface to take a Dir.
This means that Runner knows about Scoot (it deals with Snapshots), but Execer
doesn't.

Restructure the run code in Runner. It's now more clear who's responsible for
modifying what. This was necessary because checking out may take some time,
and we want to let the user cancel the job while it's happening. This has the
slight negative that the Worker returning to the client no longer means the
command is running. It would be nice if we could reinstate this. In the common
case, we have to wait for a quick checkout, but we may have to perform a fairly
slow git fetch (or a large checkout). ScootFS will eventually solve this
(because it can fault in the data).

Next steps are:

Make a Checkouter that actually checks out (from git, e.g.)

Use this directory in os execer

Allow sim_execer to examine this data (for testing)