### PR TITLE
Makefile BuildTag Update: Escape the Bang!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ vet:
 
 test:
 	# Runs only unit tests
-	go test -v -race -tags=unit $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
+	go test -v -race -tags=\!integration $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 	sh testCoverage.sh
 
 test-integration:

--- a/tests/swarmtest/swarmtest_test.go
+++ b/tests/swarmtest/swarmtest_test.go
@@ -1,4 +1,3 @@
-// +build !unit
 // +build integration
 
 package swarmtest


### PR DESCRIPTION
Turns out you can do "not this tag" semantics you just need to escape the bang!