### PR TITLE
cloud/cluster: simplify construction

### DIFF
--- a/cloud/cluster/cluster_test.go
+++ b/cloud/cluster/cluster_test.go
@@ -2,7 +2,6 @@ package cluster_test
 
 import (
 	"github.com/scootdev/scoot/cloud/cluster"
-	"github.com/scootdev/scoot/cloud/cluster/local"
 	"testing"
 )
 
@@ -73,15 +72,13 @@ type helper struct {
 	c        *cluster.Cluster
 	updateCh chan []cluster.NodeUpdate
 	f        cluster.Fetcher
-	ch       chan interface{}
+	ch       chan cluster.ClusterUpdate
 }
 
 func makeHelper(t *testing.T) *helper {
 	h := &helper{t: t}
-	h.updateCh = make(chan []cluster.NodeUpdate)
-	h.ch = make(chan interface{})
-	h.f = local.MakeFetcher()
-	h.c = cluster.NewCluster(nil, h.updateCh, h.ch, h.f)
+	h.ch = make(chan cluster.ClusterUpdate)
+	h.c = cluster.NewCluster(nil, h.ch)
 	return h
 }
 

--- a/cloud/cluster/fetch_cron.go
+++ b/cloud/cluster/fetch_cron.go
@@ -5,10 +5,9 @@ import (
 )
 
 type fetchCron struct {
-	tickCh *time.Ticker
+	tickCh <-chan time.Time
 	f      Fetcher
-	outCh  chan interface{}
-	closer chan struct{}
+	outCh  chan ClusterUpdate
 }
 
 // Returns a full list of visible nodes.
@@ -16,23 +15,23 @@ type Fetcher interface {
 	Fetch() ([]Node, error)
 }
 
-func makeFetchCron(f Fetcher, t time.Duration, ch chan interface{}) *fetchCron {
+func MakeFetchCron(f Fetcher, tickCh <-chan time.Time) chan ClusterUpdate {
+	outCh := make(chan ClusterUpdate)
 	c := &fetchCron{
-		tickCh: time.NewTicker(t),
+		tickCh: tickCh,
 		f:      f,
-		outCh:  ch,
-		closer: make(chan struct{}),
+		outCh:  outCh,
 	}
 	go c.loop()
-	return c
+	return outCh
 }
 
 func (c *fetchCron) loop() {
-	for range c.tickCh.C {
+	for range c.tickCh {
 		nodes, err := c.f.Fetch()
 		if err != nil {
 			// TODO(rcouto): Correctly handle as many errors as possible
-			return
+			continue
 		}
 		c.outCh <- nodes
 	}

--- a/cloud/cluster/local/config.go
+++ b/cloud/cluster/local/config.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"github.com/scootdev/scoot/cloud/cluster"
+	"time"
 )
 
 type ClusterLocalConfig struct {
@@ -9,6 +10,7 @@ type ClusterLocalConfig struct {
 }
 
 func (c *ClusterLocalConfig) Create() (*cluster.Cluster, error) {
-	sub, fetcher := Subscribe()
-	return cluster.NewCluster(sub.InitialMembers, sub.Updates, make(chan interface{}), fetcher), nil
+	f := MakeFetcher()
+	updates := cluster.MakeFetchCron(f, time.NewTicker(time.Second).C)
+	return cluster.NewCluster(nil, updates), nil
 }

--- a/cloud/cluster/local/fetcher.go
+++ b/cloud/cluster/local/fetcher.go
@@ -17,10 +17,6 @@ func MakeFetcher() cluster.Fetcher {
 
 type localFetcher struct{}
 
-func Subscribe() (cluster.Subscription, cluster.Fetcher) {
-	return cluster.Subscribe(), MakeFetcher()
-}
-
 func (f *localFetcher) Fetch() (nodes []cluster.Node, err error) {
 	var data []byte
 	if data, err = f.fetchData(); err != nil {

--- a/cloud/cluster/subscription.go
+++ b/cloud/cluster/subscription.go
@@ -25,11 +25,6 @@ type closer struct {
 	ticker *time.Ticker
 }
 
-func Subscribe() Subscription {
-	ticker := time.NewTicker(time.Duration(15 * time.Second))
-	return Subscription{nil, nil, &closer{ticker}}
-}
-
 func makeSubscription(initial []Node, cl *Cluster, inCh chan []NodeUpdate) Subscription {
 	s := &subscriber{
 		inCh:  inCh,

--- a/sched/config/defaults.go
+++ b/sched/config/defaults.go
@@ -2,10 +2,8 @@ package config
 
 import (
 	"fmt"
-	"time"
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/cloud/cluster"
-	"github.com/scootdev/scoot/cloud/cluster/local"
 	"github.com/scootdev/scoot/common/endpoints"
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/saga"
@@ -14,6 +12,7 @@ import (
 	"github.com/scootdev/scoot/sched/worker"
 	"github.com/scootdev/scoot/sched/worker/fake"
 	"github.com/scootdev/scoot/sched/worker/rpc"
+	"time"
 )
 
 func DefaultParser() *Parser {
@@ -59,7 +58,7 @@ func (c *ClusterMemoryConfig) Create() (*cluster.Cluster, error) {
 	for i := 0; i < c.Count; i++ {
 		workerNodes = append(workerNodes, cluster.NewIdNode(fmt.Sprintf("inmemory%d", i)))
 	}
-	return cluster.NewCluster(workerNodes, nil, nil, local.MakeFetcher()), nil
+	return cluster.NewCluster(workerNodes, nil), nil
 }
 
 type ClusterStaticConfig struct {
@@ -72,7 +71,7 @@ func (c *ClusterStaticConfig) Create() (*cluster.Cluster, error) {
 	for _, h := range c.Hosts {
 		workerNodes = append(workerNodes, cluster.NewIdNode(h))
 	}
-	return cluster.NewCluster(workerNodes, nil, nil, local.MakeFetcher()), nil
+	return cluster.NewCluster(workerNodes, nil), nil
 }
 
 type QueueMemoryConfig struct {


### PR DESCRIPTION
I found that I couldn't easily change the duration on the fetch cron because it was pulled in.

I made a few changes to make things more injected instead of constructed at the same time.

Got rid of all functions Subcribe(), which don't make sense outside of the context of a Cluster.