### PR TITLE
runner: Saver lets clients Save output 

### DIFF
--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -26,7 +26,11 @@ func main() {
 	default:
 		log.Fatalf("Unknown execer type %v", *execerType)
 	}
-	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter())
+	saver, err := local.NewSaver()
+	if err != nil {
+		log.Fatal("Cannot create Saver: ", err)
+	}
+	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter(), saver)
 	s, err := server.NewServer(r)
 	if err != nil {
 		log.Fatal("Cannot create Scoot server: ", err)

--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -26,11 +26,11 @@ func main() {
 	default:
 		log.Fatalf("Unknown execer type %v", *execerType)
 	}
-	saver, err := local.NewSaver()
+	outputCreator, err := local.NewOutputCreator()
 	if err != nil {
-		log.Fatal("Cannot create Saver: ", err)
+		log.Fatal("Cannot create OutputCreator: ", err)
 	}
-	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter(), saver)
+	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter(), outputCreator)
 	s, err := server.NewServer(r)
 	if err != nil {
 		log.Fatal("Cannot create Scoot server: ", err)

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -27,11 +27,11 @@ func main() {
 	transportFactory := thrift.NewTTransportFactory()
 
 	stats := stat.Scope("workerserver")
-	saver, err := localrunner.NewSaver()
+	outputCreator, err := localrunner.NewOutputCreator()
 	if err != nil {
-		log.Fatal("Error creating Saver: ", err)
+		log.Fatal("Error creating OutputCreatorr: ", err)
 	}
-	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil), fakesnaps.MakeInvalidCheckouter(), saver)
+	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil), fakesnaps.MakeInvalidCheckouter(), outputCreator)
 	version := func() string { return "" }
 	handler := server.NewHandler(stats, run, version)
 	err = server.Serve(handler, fmt.Sprintf("localhost:%d", *thriftPort), transportFactory, protocolFactory)

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -27,10 +27,14 @@ func main() {
 	transportFactory := thrift.NewTTransportFactory()
 
 	stats := stat.Scope("workerserver")
-	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil), fakesnaps.MakeInvalidCheckouter())
+	saver, err := localrunner.NewSaver()
+	if err != nil {
+		log.Fatal("Error creating Saver: ", err)
+	}
+	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil), fakesnaps.MakeInvalidCheckouter(), saver)
 	version := func() string { return "" }
 	handler := server.NewHandler(stats, run, version)
-	err := server.Serve(handler, fmt.Sprintf("localhost:%d", *thriftPort), transportFactory, protocolFactory)
+	err = server.Serve(handler, fmt.Sprintf("localhost:%d", *thriftPort), transportFactory, protocolFactory)
 	if err != nil {
 		log.Fatal("Error serving Worker Server: ", err)
 	}

--- a/runner/execer/execer.go
+++ b/runner/execer/execer.go
@@ -1,5 +1,9 @@
 package execer
 
+import (
+	"io"
+)
+
 // Execer lets you run one Unix command. It differs from Runner in that it does not
 // know about Snapshots or Scoot. It's just a way to run a Unix process (or fake it).
 // It's at the level of os/exec, not exec-as-a-service.
@@ -7,6 +11,9 @@ package execer
 type Command struct {
 	Argv []string
 	Dir  string
+
+	Stdout io.Writer
+	Stderr io.Writer
 	// TODO(dbentley): environment variables?
 }
 
@@ -42,7 +49,4 @@ type ProcessStatus struct {
 	State    ProcessState
 	ExitCode int
 	Error    string
-
-	StdoutURI string
-	StderrURI string
 }

--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -1,9 +1,11 @@
 package os_test
 
 import (
+	"bytes"
+	"testing"
+
 	"github.com/scootdev/scoot/runner/execer"
 	"github.com/scootdev/scoot/runner/execer/os"
-	"testing"
 )
 
 func TestAll(t *testing.T) {
@@ -30,4 +32,30 @@ func TestAll(t *testing.T) {
 		t.Fatalf("Got unexpected status running false %v", status)
 	}
 
+}
+
+func TestOutput(t *testing.T) {
+	exer := os.NewExecer()
+
+	var stdout, stderr bytes.Buffer
+
+	stdoutExpected := "hello world\n"
+	// TODO(dbentley): factor out an assertRun method
+	cmd := execer.Command{
+		Argv:   []string{"echo", "-n", stdoutExpected},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	p, err := exer.Exec(cmd)
+	if err != nil {
+		t.Fatalf("Couldn't run true %v", err)
+	}
+	status := p.Wait()
+	if status.State != execer.COMPLETE || status.ExitCode != 0 {
+		t.Fatalf("Got unexpected status running true %v", status)
+	}
+	stdoutText, stderrText := stdout.String(), stderr.String()
+	if stdoutText != stdoutExpected || stderrText != "" {
+		t.Fatalf("Incorrect output, got %q and %q; expected %q and \"\"", stdoutText, stderrText, stdoutExpected)
+	}
 }

--- a/runner/local/output.go
+++ b/runner/local/output.go
@@ -1,0 +1,65 @@
+package local
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/scootdev/scoot/runner"
+	osexecer "github.com/scootdev/scoot/runner/execer/os"
+)
+
+type localSaver struct {
+	hostname string
+}
+
+func NewSaver() (runner.Saver, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	return &localSaver{hostname: hostname}, nil
+}
+
+func (s *localSaver) Create(id string) (runner.Output, error) {
+	f, err := ioutil.TempFile("", id)
+	if err != nil {
+		return nil, err
+	}
+	absPath, err := filepath.Abs(f.Name())
+	if err != nil {
+		return nil, err
+	}
+	// We don't need a / between hostname and path because absolute paths start with /
+	uri := fmt.Sprintf("file://%s%s", s.hostname, absPath)
+	return &localOutput{f: f, uri: uri}, nil
+}
+
+type localOutput struct {
+	f   *os.File
+	uri string
+}
+
+func (o *localOutput) URI() string {
+	return o.uri
+}
+
+func (o *localOutput) Write(p []byte) (n int, err error) {
+	return o.f.Write(p)
+}
+
+func (o *localOutput) Close() error {
+	return o.f.Close()
+}
+
+// Return an underlying Writer. Why? Because some methods type assert to
+// a more specific type and are more clever (e.g., if it's an *os.File, hook it up
+// directly to a new process's stdout/stderr.)
+// We care about this cleverness, so Output both is-a and has-a Writer
+func (o *localOutput) WriterDelegate() io.Writer {
+	return o.f
+}
+
+var _ osexecer.WriterDelegater = (*localOutput)(nil)

--- a/runner/local/output.go
+++ b/runner/local/output.go
@@ -11,19 +11,20 @@ import (
 	osexecer "github.com/scootdev/scoot/runner/execer/os"
 )
 
-type localSaver struct {
+type localOutputCreator struct {
 	hostname string
 }
 
-func NewSaver() (runner.Saver, error) {
+// Create a new OutputCreator
+func NewOutputCreator() (runner.OutputCreator, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
 	}
-	return &localSaver{hostname: hostname}, nil
+	return &localOutputCreator{hostname: hostname}, nil
 }
 
-func (s *localSaver) Create(id string) (runner.Output, error) {
+func (s *localOutputCreator) Create(id string) (runner.Output, error) {
 	f, err := ioutil.TempFile("", id)
 	if err != nil {
 		return nil, err

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -10,10 +10,11 @@ import (
 	"github.com/scootdev/scoot/snapshots"
 )
 
-func NewSimpleRunner(exec execer.Execer, checkouter snapshots.Checkouter) runner.Runner {
+func NewSimpleRunner(exec execer.Execer, checkouter snapshots.Checkouter, saver runner.Saver) runner.Runner {
 	return &simpleRunner{
 		exec:       exec,
 		checkouter: checkouter,
+		saver:      saver,
 		runs:       make(map[runner.RunId]runner.ProcessStatus),
 	}
 }
@@ -22,14 +23,15 @@ func NewSimpleRunner(exec execer.Execer, checkouter snapshots.Checkouter) runner
 type simpleRunner struct {
 	exec       execer.Execer
 	checkouter snapshots.Checkouter
+	saver      runner.Saver
 	runs       map[runner.RunId]runner.ProcessStatus
-	running    *inflight
+	running    *run
 	nextRunId  int64
 	mu         sync.Mutex
 }
 
-type inflight struct {
-	runId  runner.RunId
+type run struct {
+	id     runner.RunId
 	doneCh chan struct{}
 }
 
@@ -44,7 +46,7 @@ func (r *simpleRunner) Run(cmd *runner.Command) runner.ProcessStatus {
 		return r.runs[runId]
 	}
 
-	r.running = &inflight{runId: runId, doneCh: make(chan struct{})}
+	r.running = &run{id: runId, doneCh: make(chan struct{})}
 	r.runs[runId] = runner.PreparingStatus(runId)
 
 	// Run in a new goroutine
@@ -59,7 +61,7 @@ func (r *simpleRunner) Run(cmd *runner.Command) runner.ProcessStatus {
 
 func makeRunnerStatus(st execer.ProcessStatus, runId runner.RunId) runner.ProcessStatus {
 	if st.State == execer.COMPLETE {
-		return runner.CompleteStatus(runId, st.StdoutURI, st.StderrURI, st.ExitCode)
+		return runner.CompleteStatus(runId, "", "", st.ExitCode)
 	} else if st.State == execer.FAILED {
 		return runner.ErrorStatus(runId, fmt.Errorf("error execing: %v", st.Error))
 	}
@@ -99,6 +101,7 @@ func (r *simpleRunner) Erase(run runner.RunId) {
 	}
 }
 
+// TODO(dbentley): when we timeout or abort, we should include the previous stdout/stderr URIs
 func (r *simpleRunner) updateStatus(new runner.ProcessStatus) runner.ProcessStatus {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -140,9 +143,24 @@ func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, doneCh chan 
 	}
 	defer checkout.Release()
 
+	stdout, err := r.saver.Create(fmt.Sprintf("%s-stdout", runId))
+	if err != nil {
+		r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("could not create stdout: %v", err)))
+		return
+	}
+	defer stdout.Close()
+	stderr, err := r.saver.Create(fmt.Sprintf("%s-stderr", runId))
+	if err != nil {
+		r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("could not create stderr: %v", err)))
+		return
+	}
+	defer stderr.Close()
+
 	p, err := r.exec.Exec(execer.Command{
-		Argv: cmd.Argv,
-		Dir:  checkout.Path(),
+		Argv:   cmd.Argv,
+		Dir:    checkout.Path(),
+		Stdout: stdout,
+		Stderr: stderr,
 	})
 	if err != nil {
 		r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("could not exec: %v", err)))
@@ -153,13 +171,19 @@ func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, doneCh chan 
 
 	processCh := make(chan execer.ProcessStatus, 1)
 	go func() { processCh <- p.Wait() }()
+	var st execer.ProcessStatus
 
 	// Wait for process complete or cancel
 	select {
 	case <-doneCh:
 		p.Abort()
 		return
-	case st := <-processCh:
-		r.updateStatus(makeRunnerStatus(st, runId))
+	case st = <-processCh:
 	}
+	if st.State == execer.COMPLETE {
+		r.updateStatus(runner.CompleteStatus(runId, stdout.URI(), stderr.URI(), st.ExitCode))
+	} else if st.State == execer.FAILED {
+		r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("error execing: %v", st.Error)))
+	}
+	r.updateStatus(runner.ErrorStatus(runId, fmt.Errorf("unexpected exec state: %v", st.State)))
 }

--- a/runner/local/simple_test.go
+++ b/runner/local/simple_test.go
@@ -156,10 +156,10 @@ func wait(r runner.Runner, run runner.RunId, expected runner.ProcessStatus) runn
 func newRunner() (runner.Runner, *sync.WaitGroup) {
 	wg := &sync.WaitGroup{}
 	ex := fake.NewSimExecer(wg)
-	saver, err := local.NewSaver()
+	outputCreator, err := local.NewOutputCreator()
 	if err != nil {
 		panic(err)
 	}
-	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter(), saver)
+	r := local.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter(), outputCreator)
 	return r, wg
 }

--- a/runner/output.go
+++ b/runner/output.go
@@ -1,0 +1,24 @@
+package runner
+
+import (
+	"io"
+)
+
+// Saver lets clients create new Outputs so they can save data.
+// This is how Runner can save stdout and stderr.
+// (NB: Saver is temporary until we save output into a new Snapshot)
+type Saver interface {
+	// Create an output for the given ID
+	Create(id string) (Output, error)
+}
+
+// Output is a sink for one file's worth of output
+type Output interface {
+	// Write (and close) straight to the Output
+	io.WriteCloser
+
+	// A URI to this Output. Clients can read data by accessing the URI.
+	// This lets us change how we save, because we can write to a local file,
+	// or hdfs, or s3, or any other addressable store.
+	URI() string
+}

--- a/runner/output.go
+++ b/runner/output.go
@@ -4,10 +4,11 @@ import (
 	"io"
 )
 
-// Saver lets clients create new Outputs so they can save data.
+// OutputCreator lets clients create new Outputs so they can save data.
 // This is how Runner can save stdout and stderr.
+// OutputCreator is the filesystem that creates many Outputs; Output is one file in that.
 // (NB: Saver is temporary until we save output into a new Snapshot)
-type Saver interface {
+type OutputCreator interface {
 	// Create an output for the given ID
 	Create(id string) (Output, error)
 }


### PR DESCRIPTION
Runner uses Saver to save stdout and stderr.

localSaver saves to a local file (in tempdir)

Future impls of Saver could upload to hdfs, s3, etc.

Saver is temporary until we have the ability to save all output (stdout/stderr but also created files) into a new Snapshot.