### PR TITLE
runner/execer/fake: interceptor execer picks execer based on argv

### DIFF
--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/scootdev/scoot/daemon/server"
 	"github.com/scootdev/scoot/runner/execer"
-	"github.com/scootdev/scoot/runner/execer/fake"
+	"github.com/scootdev/scoot/runner/execer/execers"
 	"github.com/scootdev/scoot/runner/execer/os"
 	"github.com/scootdev/scoot/runner/local"
 	fakesnaps "github.com/scootdev/scoot/snapshots/fake"
@@ -20,7 +20,7 @@ func main() {
 	var ex execer.Execer
 	switch *execerType {
 	case "sim":
-		ex = fake.NewSimExecer(nil)
+		ex = execers.NewSimExecer(nil)
 	case "os":
 		ex = os.NewExecer()
 	default:

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/endpoints"
-	"github.com/scootdev/scoot/runner/execer/fake"
+	"github.com/scootdev/scoot/runner/execer/execers"
+	osexec "github.com/scootdev/scoot/runner/execer/os"
 	localrunner "github.com/scootdev/scoot/runner/local"
 	fakesnaps "github.com/scootdev/scoot/snapshots/fake"
 	"github.com/scootdev/scoot/workerapi/server"
@@ -31,7 +32,9 @@ func main() {
 	if err != nil {
 		log.Fatal("Error creating OutputCreatorr: ", err)
 	}
-	run := localrunner.NewSimpleRunner(fake.NewSimExecer(nil), fakesnaps.MakeInvalidCheckouter(), outputCreator)
+
+	ex := execers.MakeSimExecerInterceptor(execers.NewSimExecer(nil), osexec.NewExecer())
+	run := localrunner.NewSimpleRunner(ex, fakesnaps.MakeInvalidCheckouter(), outputCreator)
 	version := func() string { return "" }
 	handler := server.NewHandler(stats, run, version)
 	err = server.Serve(handler, fmt.Sprintf("localhost:%d", *thriftPort), transportFactory, protocolFactory)

--- a/runner/execer/execers/intercept.go
+++ b/runner/execer/execers/intercept.go
@@ -1,0 +1,38 @@
+package execers
+
+import (
+	"github.com/scootdev/scoot/runner/execer"
+)
+
+// InterceptExecer is a Composite Execer. For each command c, if
+// Condition(c), InterceptExecer delegates to Interceptor, otherwise Default
+type InterceptExecer struct {
+	Condition   func(execer.Command) bool
+	Interceptor execer.Execer
+	Default     execer.Execer
+}
+
+func (e *InterceptExecer) Exec(command execer.Command) (execer.Process, error) {
+	if e.Condition(command) {
+		return e.Interceptor.Exec(command)
+	} else {
+		return e.Default.Exec(command)
+	}
+}
+
+// Returns whether cmd's first arg starts with UseSimExecerArg
+func StartsWithSimExecer(cmd execer.Command) bool {
+	return len(cmd.Argv) > 0 && cmd.Argv[0] == UseSimExecerArg
+}
+
+// A placeholder string that indicates a command should be run on SimExecer
+const UseSimExecerArg = "#! sim execer"
+
+// Create an InterceptExecer that will send cmd's to simExecer or delegate
+func MakeSimExecerInterceptor(simExecer, delegate execer.Execer) execer.Execer {
+	return &InterceptExecer{
+		Condition:   StartsWithSimExecer,
+		Interceptor: simExecer,
+		Default:     delegate,
+	}
+}

--- a/runner/execer/execers/intercept_test.go
+++ b/runner/execer/execers/intercept_test.go
@@ -1,0 +1,48 @@
+package execers
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/scootdev/scoot/runner/execer"
+)
+
+func TestInterceptor(t *testing.T) {
+	var wg1, wg2 sync.WaitGroup
+	ex1, ex2 := NewSimExecer(&wg1), NewSimExecer(&wg2)
+	ex := &InterceptExecer{
+		Condition:   StartsWithSimExecer,
+		Interceptor: ex1,
+		Default:     ex2,
+	}
+
+	// block1 will block on wg1; block2 on wg2
+	block1 := execer.Command{
+		Argv: []string{UseSimExecerArg, "pause", "complete 0"},
+	}
+	block2 := execer.Command{
+		Argv: []string{"pause", "complete 0"},
+	}
+
+	wg2.Add(1)
+	p, err := ex.Exec(block1)
+	if err != nil {
+		t.Fatalf("couldn't run block1: %v", err)
+	}
+	if st := p.Wait(); st.State != execer.COMPLETE {
+		t.Fatalf("block1 did not complete: %v", st)
+	}
+
+	wg2.Done()
+	wg1.Add(1)
+
+	p, err = ex.Exec(block2)
+	if err != nil {
+		t.Fatalf("couldn't run block2: %v", err)
+	}
+	if st := p.Wait(); st.State != execer.COMPLETE {
+		t.Fatalf("block2 did not complete: %v", st)
+	}
+
+	wg1.Done()
+}

--- a/runner/execer/execers/sim.go
+++ b/runner/execer/execers/sim.go
@@ -1,4 +1,4 @@
-package fake
+package execers
 
 import (
 	"fmt"
@@ -53,6 +53,9 @@ func (e *simExecer) parse(argv []string) (steps []simStep, err error) {
 }
 
 func (e *simExecer) parseArg(arg string) (simStep, error) {
+	if strings.HasPrefix(arg, "#") {
+		return &noopStep{}, nil
+	}
 	splits := strings.SplitN(arg, " ", 2)
 	opcode, rest := splits[0], ""
 	if len(splits) == 2 {
@@ -180,5 +183,11 @@ type stderrStep struct {
 
 func (s *stderrStep) run(status execer.ProcessStatus, p *simProcess) execer.ProcessStatus {
 	p.stderr.Write([]byte(s.output))
+	return status
+}
+
+type noopStep struct{}
+
+func (s *noopStep) run(status execer.ProcessStatus, p *simProcess) execer.ProcessStatus {
 	return status
 }

--- a/runner/execer/execers/sim_test.go
+++ b/runner/execer/execers/sim_test.go
@@ -1,4 +1,4 @@
-package fake_test
+package execers
 
 import (
 	"bytes"
@@ -6,16 +6,16 @@ import (
 	"testing"
 
 	"github.com/scootdev/scoot/runner/execer"
-	"github.com/scootdev/scoot/runner/execer/fake"
 )
 
 func TestSimExec(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	ex := fake.NewSimExecer(&wg)
+	ex := NewSimExecer(&wg)
 	assertRun(ex, t, complete(0), "complete 0")
 	assertRun(ex, t, complete(1), "complete 1")
 	assertRun(ex, t, complete(0), "sleep 1", "complete 0")
+	assertRun(ex, t, complete(0), "#this is a comment", "complete 0")
 	argv := []string{"pause", "complete 0"}
 	p := assertStart(ex, t, argv...)
 	wg.Done()
@@ -31,7 +31,7 @@ func TestOutput(t *testing.T) {
 		Stderr: &stderr,
 	}
 
-	ex := fake.NewSimExecer(nil)
+	ex := NewSimExecer(nil)
 	p, err := ex.Exec(cmd)
 	if err != nil {
 		t.Fatal("Error running cmd", err)

--- a/runner/local/simple_test.go
+++ b/runner/local/simple_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/scootdev/scoot/runner"
-	"github.com/scootdev/scoot/runner/execer/fake"
+	"github.com/scootdev/scoot/runner/execer/execers"
 	"github.com/scootdev/scoot/runner/local"
 	fakesnaps "github.com/scootdev/scoot/snapshots/fake"
 
@@ -155,7 +155,7 @@ func wait(r runner.Runner, run runner.RunId, expected runner.ProcessStatus) runn
 
 func newRunner() (runner.Runner, *sync.WaitGroup) {
 	wg := &sync.WaitGroup{}
-	ex := fake.NewSimExecer(wg)
+	ex := execers.NewSimExecer(wg)
 	outputCreator, err := local.NewOutputCreator()
 	if err != nil {
 		panic(err)

--- a/tests/testhelpers/generators.go
+++ b/tests/testhelpers/generators.go
@@ -2,9 +2,11 @@ package testhelpers
 
 import (
 	"fmt"
-	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"math/rand"
 	"time"
+
+	"github.com/scootdev/scoot/runner/execer/execers"
+	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 )
 
 // generates a new random number seeded with
@@ -37,7 +39,7 @@ func GenJobDefinition(rng *rand.Rand) *scoot.JobDefinition {
 func GenTask(rng *rand.Rand) *scoot.TaskDefinition {
 
 	cmd := scoot.NewCommand()
-	cmd.Argv = []string{"sleep 500", "complete 0"}
+	cmd.Argv = []string{execers.UseSimExecerArg, "sleep 500", "complete 0"}
 
 	taskDef := scoot.NewTaskDefinition()
 	taskDef.Command = cmd


### PR DESCRIPTION
InterceptorExecer looks at its first argument and, if it matches a condition, passes it to an execer (the interceptor) or if not passes it to the default.

This lets us include both sim and os execer in the same binary and then pick which to use at command runtime based n the command-line. So we can still simulate commands, or run them via the OS.