### PR TITLE
[scheduler] refactor - move jobId generation to scheduler

### DIFF
--- a/sched/generators.go
+++ b/sched/generators.go
@@ -8,6 +8,17 @@ import (
 )
 
 func GenJob(id string, numTasks int) Job {
+	jobDef := GenJobDef(numTasks)
+
+	job := Job{
+		Id:  id,
+		Def: jobDef,
+	}
+
+	return job
+}
+
+func GenJobDef(numTasks int) JobDefinition {
 	jobDef := JobDefinition{
 		JobType: "testJob",
 		Tasks:   make(map[string]TaskDefinition),
@@ -20,12 +31,7 @@ func GenJob(id string, numTasks int) Job {
 		jobDef.Tasks[taskId] = task
 	}
 
-	job := Job{
-		Id:  id,
-		Def: jobDef,
-	}
-
-	return job
+	return jobDef
 }
 
 func GenTask() TaskDefinition {

--- a/sched/scheduler/scheduler.go
+++ b/sched/scheduler/scheduler.go
@@ -7,5 +7,5 @@ import (
 )
 
 type Scheduler interface {
-	ScheduleJob(job sched.Job) error
+	ScheduleJob(jobDef sched.JobDefinition) (string, error)
 }

--- a/sched/scheduler/scheduler_mock.go
+++ b/sched/scheduler/scheduler_mock.go
@@ -29,10 +29,11 @@ func (_m *MockScheduler) EXPECT() *_MockSchedulerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockScheduler) ScheduleJob(job sched.Job) error {
-	ret := _m.ctrl.Call(_m, "ScheduleJob", job)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (_m *MockScheduler) ScheduleJob(jobDef sched.JobDefinition) (string, error) {
+	ret := _m.ctrl.Call(_m, "ScheduleJob", jobDef)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockSchedulerRecorder) ScheduleJob(arg0 interface{}) *gomock.Call {

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -127,12 +127,15 @@ func (s *statefulScheduler) ScheduleJob(jobDef sched.JobDefinition) (string, err
 
 // generates a jobId using a random uuid
 func generateJobId() string {
-	id, err := uuid.NewV4()
-	for err != nil {
-		id, err = uuid.NewV4()
-	}
 
-	return id.String()
+	// uuid.NewV4() should never actually return an error the code uses
+	// rand.Read Api to generate the uuid, which according to golang docs
+	// "Read always returns ... a nil error" https://golang.org/pkg/math/rand/#Read
+	for {
+		if id, err := uuid.NewV4(); err == nil {
+			return id.String()
+		}
+	}
 }
 
 // run the scheduler loop indefinitely

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -161,9 +161,6 @@ func Test_StatefulScheduler_JobRunsToCompletion(t *testing.T) {
 	endMessageMatcher := TaskMessageMatcher{JobId: jobId, TaskId: taskId, Data: gomock.Any()}
 	sagaLogMock.EXPECT().LogMessage(endMessageMatcher)
 	sagaLogMock.EXPECT().LogMessage(saga.MakeEndSagaMessage(jobId))
-	//sagaLogMock.EXPECT().LogMessage(saga.MakeStartTaskMessage(jobId, taskId, nil))
-	//sagaLogMock.EXPECT().LogMessage(saga.MakeEndTaskMessage(jobId, taskId, nil))
-	//sagaLogMock.EXPECT().LogMessage(saga.MakeEndSagaMessage(jobId))
 	s.step()
 
 	// advance scheduler verify task got added & scheduled

--- a/scootapi/server/run_job.go
+++ b/scootapi/server/run_job.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"github.com/nu7hatch/gouuid"
 	"github.com/scootdev/scoot/sched"
 	"github.com/scootdev/scoot/sched/scheduler"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
@@ -22,27 +21,13 @@ func runJob(scheduler scheduler.Scheduler, def *scoot.JobDefinition) (*scoot.Job
 		return nil, err
 	}
 
-	job := sched.Job{
-		Id:  generateJobId(),
-		Def: jobDef,
-	}
-
-	err = scheduler.ScheduleJob(job)
+	id, err := scheduler.ScheduleJob(jobDef)
 
 	if err != nil {
 		return nil, scoot.NewCanNotScheduleNow()
 	}
 
-	return &scoot.JobId{ID: job.Id}, nil
-}
-
-func generateJobId() string {
-	id, err := uuid.NewV4()
-	for err != nil {
-		id, err = uuid.NewV4()
-	}
-
-	return id.String()
+	return &scoot.JobId{ID: id}, nil
 }
 
 // Translates thrift job definition message to scoot domain object

--- a/scootapi/server/run_job_test.go
+++ b/scootapi/server/run_job_test.go
@@ -42,7 +42,7 @@ func Test_RunJob_WithNoTasks(t *testing.T) {
 	}
 
 	if jobId != nil {
-		t.Errorf("expected jobId to be nil when error occurs")
+		t.Errorf("expected job Id to be nil when error occurs not %v", jobId)
 	}
 }
 
@@ -61,7 +61,7 @@ func Test_RunJob_InvalidTaskId(t *testing.T) {
 	}
 
 	if jobId != nil {
-		t.Errorf("expected jobId to be nil when error occurs")
+		t.Errorf("expected job Id to be nil when error occurs not %v", jobId)
 	}
 }
 
@@ -81,7 +81,7 @@ func Test_RunJob_NoCommand(t *testing.T) {
 	}
 
 	if jobId != nil {
-		t.Error("expected jobId to be nil when error occurs")
+		t.Errorf("expected job Id to be nil when error occurs not %v", jobId)
 	}
 }
 
@@ -89,12 +89,16 @@ func Test_RunJob_ValidJob(t *testing.T) {
 	jobDef := testhelpers.GenJobDefinition(testhelpers.NewRand())
 
 	scheduler := CreateSchedulerMock(t)
-	scheduler.EXPECT().ScheduleJob(gomock.Any()).Return(nil)
+	scheduler.EXPECT().ScheduleJob(gomock.Any()).Return("testJobId", nil)
 
-	_, err := runJob(scheduler, jobDef)
+	jobId, err := runJob(scheduler, jobDef)
 
 	if err != nil {
 		t.Errorf("expected job to be successfully scheduled.  Instead error returned: %v", err)
+	}
+
+	if jobId.ID != "testJobId" {
+		t.Errorf("expected jobId to be testJobId not %v", jobId.ID)
 	}
 }
 
@@ -102,11 +106,15 @@ func Test_RunJob_SchedulerError(t *testing.T) {
 	jobDef := testhelpers.GenJobDefinition(testhelpers.NewRand())
 
 	scheduler := CreateSchedulerMock(t)
-	scheduler.EXPECT().ScheduleJob(gomock.Any()).Return(errors.New("test error"))
+	scheduler.EXPECT().ScheduleJob(gomock.Any()).Return("", errors.New("test error"))
 
-	_, err := runJob(scheduler, jobDef)
+	jobId, err := runJob(scheduler, jobDef)
 
 	if err == nil {
 		t.Error("expected error when scheduler returns an error")
+	}
+
+	if jobId != nil {
+		t.Errorf("expected job Id to be nil when error occurs not %v", jobId)
 	}
 }


### PR DESCRIPTION
Currently the JobId is generated in ScootAPI.  Logically it makes more sense for the scheduler to own this and return an Id if the job was successfully scheduled.  No functionality changes occur in this code review

No functionality Changed
* Updated Scheduler Interface to take a JobDefinition and return a JobId 
* Updated Generators 
* Moved JobId generation from scootapi to statefulscheduler

