### PR TITLE
snapshot/git: create checkouts with git clone --reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 .DS_Store
 coverage.txt
 *~
+#*#

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.8
+  - 1.7
 
 before_install:
   - make dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.6
+  - 1.8
 
 before_install:
   - make dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.7
+  - 1.6
 
 before_install:
   - make dependencies

--- a/os/temp/temp_dir.go
+++ b/os/temp/temp_dir.go
@@ -1,0 +1,38 @@
+// temp makes hierarchical temporary directories
+// it offers the same interface as ioutil, but recursive.
+// The more you use this to create temporary directories, the fewer places
+// we need to change when we want to relocate all our tempfiles.
+package temp
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// Create a new TempDir in directory dir with prefix string.
+func NewTempDir(dir, prefix string) (*TempDir, error) {
+	p, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &TempDir{Dir: p}, nil
+}
+
+// TempDir is a temporary directory, that may live under other temporary directories.
+type TempDir struct {
+	Dir string
+}
+
+// Create a new temporary directory under d
+func (d *TempDir) TempDir(prefix string) (*TempDir, error) {
+	p, err := ioutil.TempDir(d.Dir, prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &TempDir{Dir: p}, nil
+}
+
+// Create a new temporary file under d
+func (d *TempDir) TempFile(prefix string) (*os.File, error) {
+	return ioutil.TempFile(d.Dir, prefix)
+}

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -1,0 +1,111 @@
+package gitfiler
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/snapshot/git/repo"
+	"github.com/scootdev/scoot/snapshots"
+)
+
+// Utilities for Reference Repositories.
+// A Reference Repository is a way to clone repos locally so that the clone takes less time and disk space.
+// By passing --reference <local path> to a git clone, the clone will not copy the whole ODB but instead
+// hardlink. This means the clone is much faster and also takes very little extra hard disk space.
+// Cf. https://git-scm.com/docs/git-clone
+
+// RefRepoGetter lets a client get a Repository to use as a Reference Repository.
+type RefRepoGetter interface {
+	// Get gets the Repository to use as a reference repository.
+	Get() (*repo.Repository, error)
+}
+
+// RefRepoCloningCheckouter checks out by cloning a Ref Repo.
+type RefRepoCloningCheckouter struct {
+	getter RefRepoGetter
+	tmp    *temp.TempDir
+
+	repo *repo.Repository
+	mu   sync.Mutex
+}
+
+func NewRefRepoCloningCheckouter(getter RefRepoGetter, tmp *temp.TempDir) *RefRepoCloningCheckouter {
+	return &RefRepoCloningCheckouter{
+		getter: getter,
+		tmp:    tmp,
+		repo:   nil,
+	}
+}
+
+// Checkout checks out id (a raw git sha) into a Checkout.
+// It does this by making a new clone (via reference) and checking out id.
+func (c *RefRepoCloningCheckouter) Checkout(id string) (snapshots.Checkout, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.repo == nil {
+		repository, err := c.getter.Get()
+		if err != nil {
+			return nil, fmt.Errorf("gitfiler.RefRepoCloningCheckouter.clone: error getting: %v", err)
+		}
+		c.repo = repository
+	}
+
+	clone, err := c.clone()
+	if err != nil {
+		return nil, err
+	}
+
+	// Make sure we clean up if we error
+	needToClean := true
+	defer func() {
+		if needToClean {
+			err := os.RemoveAll(clone.Dir())
+			log.Println("gitfiler.RefRepoCloningCheckouter.Checkout: had to clean in Checkout", err)
+		}
+	}()
+
+	if err := clone.Checkout(id); err != nil {
+		return nil, fmt.Errorf("gitfiler.RefRepoCloningCheckouter.Checkout: could not git checkout: %v", err)
+	}
+
+	needToClean = false
+	return &RefRepoCloningCheckout{r: clone, id: id, checkouter: c}, nil
+}
+
+func (c *RefRepoCloningCheckouter) clone() (*repo.Repository, error) {
+	cloneDir, err := c.tmp.TempDir("clone-")
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("git", "clone", "-n", "--reference", c.repo.Dir(), c.repo.Dir(), cloneDir.Dir)
+	log.Println("gitfiler.RefRepoCloningCheckouter.clone: Cloning", cmd)
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("gitfiler.RefRepoCloningCheckouter.clone: error cloning: %v", err)
+	}
+
+	return repo.NewRepository(cloneDir.Dir)
+}
+
+type RefRepoCloningCheckout struct {
+	r          *repo.Repository
+	id         string
+	checkouter *RefRepoCloningCheckouter
+}
+
+func (c *RefRepoCloningCheckout) Path() string {
+	return c.r.Dir()
+}
+
+func (c *RefRepoCloningCheckout) ID() string {
+	return c.id
+}
+
+func (c *RefRepoCloningCheckout) Release() error {
+	return os.RemoveAll(c.r.Dir())
+}

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -74,7 +74,7 @@ func (c *RefRepoCloningCheckouter) Checkout(id string) (snapshot.Checkout, error
 
 	log.Println("gitfiler.RefRepoCloningCheckouter.Checkout done: ", clone.Dir())
 	needToClean = false
-	return &RefRepoCloningCheckout{r: clone, id: id, checkouter: c}, nil
+	return &RefRepoCloningCheckout{repo: clone, id: id, checkouter: c}, nil
 }
 
 func (c *RefRepoCloningCheckouter) clone() (*repo.Repository, error) {
@@ -94,13 +94,13 @@ func (c *RefRepoCloningCheckouter) clone() (*repo.Repository, error) {
 }
 
 type RefRepoCloningCheckout struct {
-	r          *repo.Repository
+	repo       *repo.Repository
 	id         string
 	checkouter *RefRepoCloningCheckouter
 }
 
 func (c *RefRepoCloningCheckout) Path() string {
-	return c.r.Dir()
+	return c.repo.Dir()
 }
 
 func (c *RefRepoCloningCheckout) ID() string {
@@ -108,5 +108,5 @@ func (c *RefRepoCloningCheckout) ID() string {
 }
 
 func (c *RefRepoCloningCheckout) Release() error {
-	return os.RemoveAll(c.r.Dir())
+	return os.RemoveAll(c.repo.Dir())
 }

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 
 	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/snapshot"
 	"github.com/scootdev/scoot/snapshot/git/repo"
-	"github.com/scootdev/scoot/snapshots"
 )
 
 // Utilities for Reference Repositories.
@@ -43,7 +43,7 @@ func NewRefRepoCloningCheckouter(getter RefRepoGetter, tmp *temp.TempDir) *RefRe
 
 // Checkout checks out id (a raw git sha) into a Checkout.
 // It does this by making a new clone (via reference) and checking out id.
-func (c *RefRepoCloningCheckouter) Checkout(id string) (snapshots.Checkout, error) {
+func (c *RefRepoCloningCheckouter) Checkout(id string) (snapshot.Checkout, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.repo == nil {

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -72,6 +72,7 @@ func (c *RefRepoCloningCheckouter) Checkout(id string) (snapshot.Checkout, error
 		return nil, fmt.Errorf("gitfiler.RefRepoCloningCheckouter.Checkout: could not git checkout: %v", err)
 	}
 
+	log.Println("gitfiler.RefRepoCloningCheckouter.Checkout done: ", clone.Dir())
 	needToClean = false
 	return &RefRepoCloningCheckout{r: clone, id: id, checkouter: c}, nil
 }

--- a/snapshot/git/gitfiler/checkouter_test.go
+++ b/snapshot/git/gitfiler/checkouter_test.go
@@ -1,0 +1,118 @@
+package gitfiler
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/snapshot/git/repo"
+)
+
+func TestCheckouter(t *testing.T) {
+	tmp, err := temp.NewTempDir("", "checkouter_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var id1, id2 string
+	repo, err := CreateReferenceRepo(tmp, &id1, &id2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkouter := NewRefRepoCloningCheckouter(&constantGetter{repo}, tmp)
+	c1, err := checkouter.Checkout(id1)
+	if err != nil {
+		t.Fatalf("error checking out %v, %v", id1, err)
+	}
+	c2, err := checkouter.Checkout(id2)
+	if err != nil {
+		t.Fatalf("error checking out %v, %v", id2, err)
+	}
+	if c1.Path() == c2.Path() {
+		t.Fatalf("checkouts should have separate paths: %v %v", c1.Path(), c2.Path())
+	}
+
+	// Make sure they have separate file contents at the same time
+	data, err := ioutil.ReadFile(filepath.Join(c1.Path(), "file.txt"))
+	if err != nil || string(data) != "first" {
+		t.Fatalf("error reading file.txt: %q %v (expected \"first\" <nil>)", data, err)
+	}
+
+	data, err = ioutil.ReadFile(filepath.Join(c2.Path(), "file.txt"))
+	if err != nil || string(data) != "second" {
+		t.Fatalf("error reading file.txt: %q %v (expected \"second\" <nil>)", data, err)
+	}
+
+	c1.Release()
+	c2.Release()
+
+	_, err = checkouter.Checkout("Not a valid git sha1")
+	if err == nil {
+		t.Fatalf("should not have been able to check out; %v", c1)
+	}
+}
+
+type constantGetter struct {
+	repo *repo.Repository
+}
+
+func (g *constantGetter) Get() (*repo.Repository, error) {
+	return g.repo, nil
+}
+
+func CreateReferenceRepo(tmp *temp.TempDir, id1 *string, id2 *string) (*repo.Repository, error) {
+	// git init
+	dir, err := tmp.TempDir("ref-repo-")
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir.Dir
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error init'ing: %v", err)
+	}
+
+	// create the repo
+	r, err := repo.NewRepository(dir.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a commit with file.txt = "first"
+	filename := filepath.Join(dir.Dir, "file.txt")
+	if err = ioutil.WriteFile(filename, []byte("first"), 0777); err != nil {
+		return nil, err
+	}
+
+	if _, err = r.Run("add", "file.txt"); err != nil {
+		return nil, err
+	}
+	if _, err = r.Run("commit", "-am", "first post"); err != nil {
+		return nil, err
+	}
+	if id, err := r.RunSha("rev-parse", "HEAD"); err != nil {
+		return nil, err
+	} else {
+		*id1 = id
+	}
+
+	// Create a commit with file.txt = "second"
+	if err = ioutil.WriteFile(filename, []byte("second"), 0777); err != nil {
+		return nil, err
+	}
+	if _, err = r.Run("commit", "-am", "second post"); err != nil {
+		return nil, err
+	}
+	if id, err := r.RunSha("rev-parse", "HEAD"); err != nil {
+		return nil, err
+	} else {
+		*id2 = id
+	}
+
+	return r, nil
+}

--- a/snapshot/git/gitfiler/checkouter_test.go
+++ b/snapshot/git/gitfiler/checkouter_test.go
@@ -83,6 +83,13 @@ func CreateReferenceRepo(tmp *temp.TempDir, id1 *string, id2 *string) (*repo.Rep
 		return nil, err
 	}
 
+	if _, err = r.Run("config", "user.name", "Scoot Test"); err != nil {
+		return nil, err
+	}
+	if _, err = r.Run("config", "user.email", "scoottest@scootdev.github.io"); err != nil {
+		return nil, err
+	}
+
 	// Create a commit with file.txt = "first"
 	filename := filepath.Join(dir.Dir, "file.txt")
 	if err = ioutil.WriteFile(filename, []byte("first"), 0777); err != nil {

--- a/snapshot/git/gitfiler/checkouter_test.go
+++ b/snapshot/git/gitfiler/checkouter_test.go
@@ -92,6 +92,7 @@ func CreateReferenceRepo(tmp *temp.TempDir, id1 *string, id2 *string) (*repo.Rep
 	if _, err = r.Run("add", "file.txt"); err != nil {
 		return nil, err
 	}
+	// Run it with just this thing
 	if _, err = r.Run("commit", "-am", "first post"); err != nil {
 		return nil, err
 	}

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -27,6 +27,7 @@ func (r *Repository) Run(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = r.dir
 	data, err := cmd.Output()
+	log.Println("repo.Repository.Run complete", err)
 	return string(data), err
 }
 

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -28,9 +28,11 @@ func (r *Repository) Run(args ...string) (string, error) {
 	cmd.Dir = r.dir
 	data, err := cmd.Output()
 	log.Println("repo.Repository.Run complete", err)
-	if err != nil {
-		log.Println("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
-	}
+	// Print stderr, which exists only in go 1.6 and later.
+	// TODO(dbentley): reenable once we're on go 1.7
+	// if err != nil {
+	// 	log.Println("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
+	// }
 	return string(data), err
 }
 
@@ -50,10 +52,10 @@ func (r *Repository) Checkout(id string) error {
 }
 
 func validateSha(sha string) (string, error) {
-	if len(sha) != 41 || sha[40] != '\n' {
-		return "", fmt.Errorf("sha not 41 characters: %q", sha)
+	if len(sha) == 40 || len(sha) == 41 && sha[40] == '\n' {
+		return sha[0:40], nil
 	}
-	return sha[0:40], nil
+	return "", fmt.Errorf("sha not 40 or 41 (with a \\n) characters: %q", sha)
 }
 
 // NewRepo creates a new Repository for path `dir`.

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -1,0 +1,71 @@
+package repo
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// Utilities for operating on a git repo.
+// Scoot often ends up with multiple git repos. E.g., one reference repo and then each
+// checkout is in its own repo.
+
+// Repository represents a valid Git repository.
+type Repository struct {
+	dir string
+}
+
+// Where r lives on disk
+func (r *Repository) Dir() string {
+	return r.dir
+}
+
+// Run a git command in r
+func (r *Repository) Run(args ...string) (string, error) {
+	log.Println("repo.Repository.Run", args)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = r.dir
+	data, err := cmd.Output()
+	return string(data), err
+}
+
+// Run a git command that returns a sha.
+func (r *Repository) RunSha(args ...string) (string, error) {
+	out, err := r.Run(args...)
+	if err != nil {
+		return out, err
+	}
+	return validateSha(out)
+}
+
+// Checkout an id in r
+func (r *Repository) Checkout(id string) error {
+	_, err := r.Run("checkout", id)
+	return err
+}
+
+func validateSha(sha string) (string, error) {
+	if len(sha) != 41 || sha[40] != '\n' {
+		return "", fmt.Errorf("sha not 41 characters: %q", sha)
+	}
+	return sha[0:40], nil
+}
+
+// NewRepo creates a new Repository for path `dir`.
+// It checks that `dir` is a valid path.
+func NewRepository(dir string) (*Repository, error) {
+	// TODO(dbentley): make sure we handle the case that path is in a git repo,
+	// but is not the root of a git repo
+	repo := &Repository{dir}
+	// TODO(dbentley): we'd prefer to use features present in git 2.5+, but are stuck on 2.4 for now
+	// E.g., --resolve-git-dir or --git-path
+	topLevel, err := repo.Run("rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, err
+	}
+	topLevel = strings.Replace(topLevel, "\n", "", -1)
+	log.Println("git.NewRepository:", dir, topLevel)
+	repo.dir = topLevel
+	return repo, nil
+}

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -29,7 +29,7 @@ func (r *Repository) Run(args ...string) (string, error) {
 	data, err := cmd.Output()
 	log.Println("repo.Repository.Run complete", err)
 	if err != nil {
-		log.Println("repo.Repository.Run error:", err.(*exec.ExitError).Stderr)
+		log.Println("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
 	}
 	return string(data), err
 }

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -28,6 +28,9 @@ func (r *Repository) Run(args ...string) (string, error) {
 	cmd.Dir = r.dir
 	data, err := cmd.Output()
 	log.Println("repo.Repository.Run complete", err)
+	if err != nil {
+		log.Println("repo.Repository.Run error:", err.(*exec.ExitError).Stderr)
+	}
 	return string(data), err
 }
 


### PR DESCRIPTION
Using git clone reference lets us have many clones without taking lots of disk space. This will let us do work in the background (eventually; not yet implemented).