### PR TITLE
snapshot/git/gitfiler: refactor Checkouter

### DIFF
--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/scootdev/scoot/daemon/server"
+	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner/execer"
 	"github.com/scootdev/scoot/runner/execer/execers"
 	"github.com/scootdev/scoot/runner/execer/os"
@@ -26,7 +27,13 @@ func main() {
 	default:
 		log.Fatalf("Unknown execer type %v", *execerType)
 	}
-	outputCreator, err := local.NewOutputCreator()
+
+	tempDir, err := temp.TempDirDefault()
+	if err != nil {
+		log.Fatal("error creating temp dir: ", err)
+	}
+
+	outputCreator, err := local.NewOutputCreator(tempDir)
 	if err != nil {
 		log.Fatal("Cannot create OutputCreator: ", err)
 	}

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/endpoints"
+	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner/execer/execers"
 	osexec "github.com/scootdev/scoot/runner/execer/os"
 	localrunner "github.com/scootdev/scoot/runner/local"
@@ -27,8 +28,13 @@ func main() {
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
 	transportFactory := thrift.NewTTransportFactory()
 
+	tempDir, err := temp.TempDirDefault()
+	if err != nil {
+		log.Fatal("error creating temp dir: ", err)
+	}
+
 	stats := stat.Scope("workerserver")
-	outputCreator, err := localrunner.NewOutputCreator()
+	outputCreator, err := localrunner.NewOutputCreator(tempDir)
 	if err != nil {
 		log.Fatal("Error creating OutputCreatorr: ", err)
 	}

--- a/os/temp/temp_dir.go
+++ b/os/temp/temp_dir.go
@@ -70,7 +70,7 @@ func TempDirHere() (*TempDir, error) {
 	}
 
 	if err = os.Setenv("TMPDIR", cwd); err != nil {
-		return nil, fmt.Errorf("temp.TempDirHere: couldn't setenv", err)
+		return nil, fmt.Errorf("temp.TempDirHere: couldn't setenv %v", err)
 	}
 
 	return NewTempDir(cwd, "scoot-tmp-")

--- a/runner/local/output.go
+++ b/runner/local/output.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
 	osexecer "github.com/scootdev/scoot/runner/execer/os"
 )
@@ -16,7 +17,7 @@ type localOutputCreator struct {
 }
 
 // Create a new OutputCreator
-func NewOutputCreator() (runner.OutputCreator, error) {
+func NewOutputCreator(tmp *temp.TempDir) (runner.OutputCreator, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -117,6 +117,7 @@ func (r *simpleRunner) updateStatus(new runner.ProcessStatus) (runner.ProcessSta
 		// We are ending the running task.
 		// depend on the invariant that there is at most 1 run with !state.IsDone(),
 		// so if we're changing a Process from not Done to Done it must be running
+		log.Printf("local.simpleRunner: run done. %+v", new)
 		close(r.running.doneCh)
 		r.running = nil
 	}

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -126,6 +127,7 @@ func (r *simpleRunner) updateStatus(new runner.ProcessStatus) (runner.ProcessSta
 
 // run cmd in the background, writing results to r as id, unless doneCh is closed
 func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, doneCh chan struct{}) {
+	log.Printf("local.simpleRunner.run running: ID: %v, cmd: %+v", runId, cmd)
 	checkout, err, checkoutDone := (snapshot.Checkout)(nil), (error)(nil), make(chan struct{}, 1)
 	go func() {
 		checkout, err = r.checkouter.Checkout(cmd.SnapshotId)
@@ -143,6 +145,8 @@ func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, doneCh chan 
 		return
 	}
 	defer checkout.Release()
+
+	log.Printf("local.simpleRunner.run checkout: %v", checkout.Path())
 
 	stdout, err := r.outputCreator.Create(fmt.Sprintf("%s-stdout", runId))
 	if err != nil {

--- a/runner/local/simple_test.go
+++ b/runner/local/simple_test.go
@@ -5,15 +5,15 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"sync"
+	"testing"
 	"time"
 
+	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
 	"github.com/scootdev/scoot/runner/execer/execers"
 	"github.com/scootdev/scoot/runner/local"
 	"github.com/scootdev/scoot/snapshot/snapshots"
-
-	"sync"
-	"testing"
 )
 
 func TestRun(t *testing.T) {
@@ -165,7 +165,12 @@ func wait(r runner.Runner, run runner.RunId, expected runner.ProcessStatus) runn
 func newRunner() (runner.Runner, *sync.WaitGroup) {
 	wg := &sync.WaitGroup{}
 	ex := execers.NewSimExecer(wg)
-	outputCreator, err := local.NewOutputCreator()
+	tempDir, err := temp.TempDirDefault()
+	if err != nil {
+		panic(err)
+	}
+
+	outputCreator, err := local.NewOutputCreator(tempDir)
 	if err != nil {
 		panic(err)
 	}

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -31,7 +31,7 @@ func NewSingleRepoPool(repoGetter RepoGetter, doneCh chan struct{}) *RepoPool {
 	return singlePool
 }
 
-func NewSingeRepoCheckouter(repoGetter RepoGetter, doneCh chan struct{}) *Checkouter {
+func NewSingleRepoCheckouter(repoGetter RepoGetter, doneCh chan struct{}) *Checkouter {
 	pool := NewSingleRepoPool(repoGetter, doneCh)
 	return NewCheckouter(pool)
 }

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -16,6 +16,7 @@ type Checkouter struct {
 	repos *RepoPool
 }
 
+// An arbitrary revision. As mentioned below, we should get rid of this altogether
 const DEFAULT_REV = "1dda9fbde682e4922a0d5709c5539f573db4cc54"
 
 // Checkout checks out id (a raw git sha) into a Checkout.

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -9,13 +9,18 @@ import (
 	"github.com/scootdev/scoot/snapshot/git/repo"
 )
 
+// A Reference Repository is a way to clone repos locally so that the clone takes less time and disk space.
+// By passing --reference <local path> to a git clone, the clone will not copy the whole ODB but instead
+// hardlink. This means the clone is much faster and also takes very little extra hard disk space.
+// Cf. https://git-scm.com/docs/git-clone
+
 // cloner clones a repo using --reference based on a reference repo
 type refCloner struct {
 	refPool   *RepoPool
 	clonesDir *temp.TempDir
 }
 
-// clone clones a repo
+// Get gets a repo with git clone --reference
 func (c *refCloner) Get() (*repo.Repository, error) {
 	ref, err := c.refPool.Get()
 	defer c.refPool.Release(ref, err)

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -1,0 +1,43 @@
+package gitfiler
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"sync"
+
+	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/snapshot/git/repo"
+)
+
+// cloner clones a repo using --reference based on a reference repo
+type cloner struct {
+	clonesDir *temp.TempDir
+
+	ref *repo.Repository
+	err error
+
+	// wg waits for init
+	wg sync.WaitGroup
+}
+
+// clone clones a repo
+func (c *cloner) clone() (*repo.Repository, error) {
+	c.wg.Wait()
+	if c.err != nil {
+		return nil, c.err
+	}
+	cloneDir, err := c.clonesDir.TempDir("clone-")
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("git", "clone", "-n", "--reference", c.ref.Dir(), c.ref.Dir(), cloneDir.Dir)
+	log.Println("gitfiler.RefRepoCloningCheckouter.clone: Cloning", cmd)
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("gitfiler.RefRepoCloningCheckouter.clone: error cloning: %v", err)
+	}
+
+	return repo.NewRepository(cloneDir.Dir)
+}

--- a/snapshot/git/gitfiler/doc.go
+++ b/snapshot/git/gitfiler/doc.go
@@ -1,0 +1,13 @@
+// gitfiler offers Scoot Snapshot Filer operations access to git
+// It does this with a few related by separate structures:
+//
+// RepoGetter is an interface to get a Repository.
+//
+// refCloner gets new repos by running git clone --reference against a reference repo
+//
+// RepoPool controls concurrent access to repos
+//
+// Checkouter makes Checkouts by pulling a Repository from a RepoPool and performing a git checkout
+//
+// setup.go holds utility functions to create new Checkouters
+package gitfiler

--- a/snapshot/git/gitfiler/pool.go
+++ b/snapshot/git/gitfiler/pool.go
@@ -4,11 +4,13 @@ import (
 	"github.com/scootdev/scoot/snapshot/git/repo"
 )
 
+// repoAndError holds a repo and an error (just so we can pass it across a channel)
 type repoAndError struct {
 	repo *repo.Repository
 	err  error
 }
 
+// NewRepoPool creates a new RepoPool populated with existing repos and a getter that can get new ones
 func NewRepoPool(getter RepoGetter, repos []*repo.Repository, doneCh chan struct{}) *RepoPool {
 	freeList := make([]repoAndError, len(repos))
 	for i, v := range repos {
@@ -17,7 +19,7 @@ func NewRepoPool(getter RepoGetter, repos []*repo.Repository, doneCh chan struct
 
 	p := &RepoPool{
 		getter:    getter,
-		releaseCh: make(chan repoAndError, 1),
+		releaseCh: make(chan repoAndError),
 		reserveCh: make(chan repoAndError),
 		doneCh:    doneCh,
 		freeList:  freeList,
@@ -26,35 +28,41 @@ func NewRepoPool(getter RepoGetter, repos []*repo.Repository, doneCh chan struct
 	return p
 }
 
-// repoPool holds repos ready to be used.
-// If none are ready, it will clone a new one in the background using cloner
+// RepoPool lets clients Get a Repository for an operation, and then Release it when done
+// RepoPool can create a new Repository by using a supplied RepoGetter.
+// New repos can be added by the client by Release'ing a new Repository
+// Cf. sync's Pool
 type RepoPool struct {
 	getter RepoGetter
 
 	releaseCh chan repoAndError
 	reserveCh chan repoAndError
+	getCh     chan repoAndError
 	doneCh    chan struct{}
 
 	freeList []repoAndError
 }
 
-// Release releases a clone that is no longer needed
-func (p *RepoPool) Release(repo *repo.Repository, err error) {
-	p.releaseCh <- repoAndError{repo, err}
-}
-
-// Reserve reserves a clone, or returns an error if it cannot be cloned
+// Get gets a repo, or returns an error if it can't be gotten
 func (p *RepoPool) Get() (*repo.Repository, error) {
 	r := <-p.reserveCh
 	return r.repo, r.err
 }
 
+// Release releases a repo that is no longer needed
+func (p *RepoPool) Release(repo *repo.Repository, err error) {
+	p.releaseCh <- repoAndError{repo, err}
+}
+
 func (p *RepoPool) loop() {
 	for {
-		if len(p.freeList) == 0 && p.getter != nil {
+		// kick off a get if we're empty, know how to get, and aren't already getting
+		if len(p.freeList) == 0 && p.getter != nil && p.getCh == nil {
+			// buffer of 1 to unblock background get if we're done before it finishes
+			p.getCh = make(chan repoAndError, 1)
 			go func() {
 				r, err := p.getter.Get()
-				p.Release(r, err)
+				p.getCh <- repoAndError{r, err}
 			}()
 		}
 
@@ -70,6 +78,9 @@ func (p *RepoPool) loop() {
 			p.freeList = p.freeList[1:]
 		case r := <-p.releaseCh:
 			p.freeList = append(p.freeList, r)
+		case r := <-p.getCh:
+			p.freeList = append(p.freeList, r)
+			p.getCh = nil
 		case <-p.doneCh:
 			return
 		}

--- a/snapshot/git/gitfiler/pool.go
+++ b/snapshot/git/gitfiler/pool.go
@@ -1,0 +1,78 @@
+package gitfiler
+
+import (
+	"github.com/scootdev/scoot/snapshot/git/repo"
+)
+
+type repoAndError struct {
+	repo *repo.Repository
+	err  error
+}
+
+func newRepoPool(cloner *cloner, doneCh chan struct{}) *repoPool {
+	p := &repoPool{
+		cloner:    cloner,
+		releaseCh: make(chan *repo.Repository),
+		reserveCh: make(chan repoAndError),
+		doneCh:    doneCh,
+	}
+	go p.loop()
+	return p
+}
+
+// repoPool holds repos ready to be used.
+// If none are ready, it will clone a new one in the background using cloner
+type repoPool struct {
+	cloner *cloner
+
+	releaseCh chan *repo.Repository
+	reserveCh chan repoAndError
+	cloneCh   chan repoAndError
+	doneCh    chan struct{}
+
+	freeList []repoAndError
+}
+
+// Release releases a clone that is no longer needed
+func (p *repoPool) Release(clone *repo.Repository) {
+	p.releaseCh <- clone
+}
+
+// Reserve reserves a clone, or returns an error if it cannot be cloned
+func (p *repoPool) Reserve() (*repo.Repository, error) {
+	r := <-p.reserveCh
+	return r.repo, r.err
+}
+
+func (p *repoPool) loop() {
+	for {
+		// If we don't have any free repos, and we're not currently cloning, start a clone
+		if len(p.freeList) == 0 && p.cloneCh == nil {
+			p.cloneCh = make(chan repoAndError)
+			go func() {
+				r, err := p.cloner.clone()
+				p.cloneCh <- repoAndError{r, err}
+			}()
+		}
+
+		var reserveCh chan repoAndError
+		var free repoAndError
+		if len(p.freeList) > 0 {
+			reserveCh, free = p.reserveCh, p.freeList[0]
+		}
+
+		// Serve, either receiving or sending repos
+		select {
+		case reserveCh <- free:
+			p.freeList = p.freeList[1:]
+		case r := <-p.releaseCh:
+			p.freeList = append(p.freeList, repoAndError{repo: r})
+		case r := <-p.cloneCh:
+			p.freeList = append(p.freeList, r)
+			p.cloneCh = nil
+		case <-p.doneCh:
+			return
+		}
+
+	}
+}

--- a/snapshot/git/gitfiler/setup.go
+++ b/snapshot/git/gitfiler/setup.go
@@ -1,0 +1,52 @@
+package gitfiler
+
+import (
+	"io/ioutil"
+	"path"
+
+	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/snapshot/git/repo"
+)
+
+// Utilities for creating Checkouters.
+
+// RepoGetter lets a client get a Repository to use as a Reference Repository.
+type RepoGetter interface {
+	// Get gets the Repository to use as a reference repository.
+	Get() (*repo.Repository, error)
+}
+
+// A Pool that will only have a signle repo, populated by repoGetter, that serves as long as doneCh
+func NewSingleRepoPool(repoGetter RepoGetter, doneCh chan struct{}) *RepoPool {
+	singlePool := NewRepoPool(nil, nil, doneCh)
+	go func() {
+		r, err := repoGetter.Get()
+		singlePool.Release(r, err)
+	}()
+	return singlePool
+}
+
+// A Checkouter that checks out from a single repo populated by a NewSingleRepoPool)
+func NewSingleRepoCheckouter(repoGetter RepoGetter, doneCh chan struct{}) *Checkouter {
+	pool := NewSingleRepoPool(repoGetter, doneCh)
+	return NewCheckouter(pool)
+}
+
+// A Checkouter that creates a new repo with git clone --reference for each checkout
+func NewRefRepoCloningCheckouter(refRepoGetter RepoGetter, clonesDir *temp.TempDir, doneCh chan struct{}) *Checkouter {
+	refPool := NewSingleRepoPool(refRepoGetter, doneCh)
+
+	cloner := &refCloner{refPool: refPool, clonesDir: clonesDir}
+	var clones []*repo.Repository
+	fis, _ := ioutil.ReadDir(clonesDir.Dir)
+	for _, fi := range fis {
+		// TODO(dbentley): maybe we should check that these clones are in fact clones
+		// of the reference repo? Using some kind of git commands to determine its upstream?
+		if clone, err := repo.NewRepository(path.Join(clonesDir.Dir, fi.Name())); err == nil {
+			clones = append(clones, clone)
+		}
+	}
+
+	pool := NewRepoPool(cloner, clones, doneCh)
+	return NewCheckouter(pool)
+}

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -45,12 +45,6 @@ func (r *Repository) RunSha(args ...string) (string, error) {
 	return validateSha(out)
 }
 
-// Checkout an id in r
-func (r *Repository) Checkout(id string) error {
-	_, err := r.Run("checkout", id)
-	return err
-}
-
 func validateSha(sha string) (string, error) {
 	if len(sha) == 40 || len(sha) == 41 && sha[40] == '\n' {
 		return sha[0:40], nil


### PR DESCRIPTION
Break down gitfiler a bit more. 

Checkouter: Checks out a Snapshot ID by running git checkout
RepoGetter: interface to get a Repo
RefCloner: RepoGetter that gets a repo by running git clone --reference
RepoPool: holds Repos and manages concurrent access. Can get new ones if given a RepoGetter

By building these blocks together in different ways, a client can choose whether to always make a new clone (setup.go.NewRefRepoCloningCheckouter) or always use the same Repo (setup.go.NewSingleRepoCheckouter)

Document in gitfiler/doc.go

log in local.simpleRunner to make it easier to follow in workerServer's stderr

Use TempDir in more places to be more consistent about where we store output.