### PR TITLE
[Scheduler] flags should not be common

### DIFF
--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -5,10 +5,17 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/binaries/scheduler/config"
+	"github.com/scootdev/scoot/common/endpoints"
+	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/scootapi/server"
 	"log"
 )
+
+// Set Flags Needed by this Server
+var addr = flag.String("addr", "localhost:9090", "Bind address for api server.")
+var httpPort = flag.Int("http_port", 9091, "port to serve http on")
 
 var configFileName = flag.String("config", "local.json", "Scheduler Config File")
 
@@ -23,5 +30,13 @@ func main() {
 	}
 
 	bag, schema := server.Defaults()
+	bag.PutMany(
+		func() (thrift.TServerTransport, error) { return thrift.NewTServerSocket(*addr) },
+		func(s stats.StatsReceiver) *endpoints.TwitterServer {
+			return endpoints.NewTwitterServer(fmt.Sprintf(":%d", *httpPort), s)
+		},
+	)
+
+	log.Println("Starting Cloud Scoot API Server & Scheduler on", *addr)
 	server.RunServer(bag, schema, []byte(config))
 }

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -1,17 +1,14 @@
 package server
 
 import (
-	"flag"
-	"fmt"
 	"log"
 
-	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/config/jsonconfig"
 	"github.com/scootdev/scoot/ice"
 
 	// For putting into ice.MagicBag
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/endpoints"
-	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/saga"
 	"github.com/scootdev/scoot/sched/scheduler"
 
@@ -19,10 +16,6 @@ import (
 	"github.com/scootdev/scoot/config/scootconfig"
 	"github.com/scootdev/scoot/saga/sagalogs"
 )
-
-// Set Flags Needed by this Server
-var addr = flag.String("addr", "localhost:9090", "Bind address for api server.")
-var httpPort = flag.Int("http_port", 9091, "port to serve http on")
 
 type servers struct {
 	thrift thrift.TServer
@@ -39,13 +32,9 @@ func makeServers(
 func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 	bag := ice.NewMagicBag()
 	bag.PutMany(
-		func() (thrift.TServerTransport, error) { return thrift.NewTServerSocket(*addr) },
 		endpoints.MakeStatsReceiver,
 		MakeServer,
 		NewHandler,
-		func(s stats.StatsReceiver) *endpoints.TwitterServer {
-			return endpoints.NewTwitterServer(fmt.Sprintf(":%d", *httpPort), s)
-		},
 		makeServers,
 		saga.MakeSagaCoordinator,
 		sagalogs.MakeInMemorySagaLog,
@@ -78,8 +67,6 @@ func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 // Starts the Server based on the MagicBag and config schema provided
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
-	log.Println("Starting Cloud Scoot API Server & Scheduler on", *addr)
-
 	// Parse Config
 	mod, err := schema.Parse(config)
 	if err != nil {


### PR DESCRIPTION
Binary Flags should not be in apiserver setup code.  These are actually different per binary.  In Source they are based on http and thrift endpoints, and are actually different (my mistake!)

Refactored code that uses flags out of common server setup code and into main.  