### PR TITLE
[scheduler] fixing uneven distribution of tasks bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ vet:
 
 test:
 	# Runs only unit tests
-	go test -v -race -tags=\!integration $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
+	go test -race -tags=\!integration $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 	sh testCoverage.sh
 
 test-integration:
 	# Runs all tests including integration
-	go test -v -tags=integration $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
+	go test -tags=integration $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 
 testlocal: generate test
 

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"errors"
+	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/scootdev/scoot/cloud/cluster"
 	"github.com/scootdev/scoot/common/stats"
@@ -125,6 +126,45 @@ func Test_StatefulScheduler_AddJob(t *testing.T) {
 	if !ok {
 		t.Errorf("Expected the %v to be an inProgressJobs", id)
 	}
+}
+
+// verify that jobs are distributed evenly
+func Test_StatefulScheduler_TasksDistributedEvenly(t *testing.T) {
+	jobDef := sched.GenJobDef(1000)
+	s := makeDefaultStatefulScheduler()
+
+	//initialize NodeMap to keep track of tasks per node
+	taskMap := make(map[string]cluster.NodeId)
+
+	/*jobId, _ :=*/ s.ScheduleJob(jobDef)
+	s.step()
+
+	for len(s.inProgressJobs) > 0 {
+		s.step()
+
+		for nodeId, state := range s.clusterState.nodes {
+			if state.runningTask != noTask {
+				taskMap[state.runningTask] = nodeId
+			}
+		}
+	}
+
+	taskCountMap := make(map[cluster.NodeId]int)
+	for _, nodeId := range taskMap {
+		taskCountMap[nodeId]++
+	}
+
+	// The in memory workers aren't doing anything interesting except sleeping distribution
+	// should be even with in 190 - 210 nodes otherwise something is wrong.
+	for nodeId, taskCount := range taskCountMap {
+		if taskCount < 190 || taskCount > 210 {
+			t.Fatalf(`Tasks were not evenly distributed across nodes.  Expected each node
+				to have 190 to 210 tasks executed on it. %v had an unequal number of tasks %v scheduled 
+				on it.  TaskCountMap: %+v`, nodeId, taskCount, taskCountMap)
+		}
+	}
+
+	fmt.Printf("Task to Node Distribution: %+v", taskCountMap)
 }
 
 // Ensure a single job with one task runs to completion, updates

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -155,9 +155,9 @@ func Test_StatefulScheduler_TasksDistributedEvenly(t *testing.T) {
 	}
 
 	// The in memory workers aren't doing anything interesting except sleeping distribution
-	// should be even with in 190 - 210 nodes otherwise something is wrong.
+	// should be even with in 180 - 220 nodes otherwise something is wrong.
 	for nodeId, taskCount := range taskCountMap {
-		if taskCount < 190 || taskCount > 210 {
+		if taskCount < 180 || taskCount > 220 {
 			t.Fatalf(`Tasks were not evenly distributed across nodes.  Expected each node
 				to have 190 to 210 tasks executed on it. %v had an unequal number of tasks %v scheduled 
 				on it.  TaskCountMap: %+v`, nodeId, taskCount, taskCountMap)


### PR DESCRIPTION
@ryancouto noticed that all tasks were getting scheduled to one worker.  This is because of a for loop concurrency bug.  All nodes got scheduled once, but only one ever got marked as unscheduled.  Fixed the bug, and added a test case to ensure we are evenly distributing tasks across our nodes.

Also switched out log for fmt in stateful_scheduler.go