### PR TITLE
runner/local ensure checkout release in runner, cleanup

### DIFF
--- a/binaries/scheduler/config/config.go
+++ b/binaries/scheduler/config/config.go
@@ -182,9 +182,9 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"config/config.go": configConfigGo,
+	"config/config.go":     configConfigGo,
 	"config/inMemory.json": configInmemoryJson,
-	"config/local.json": configLocalJson,
+	"config/local.json":    configLocalJson,
 }
 
 // AssetDir returns the file names below a certain
@@ -226,11 +226,12 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"config": &bintree{nil, map[string]*bintree{
-		"config.go": &bintree{configConfigGo, map[string]*bintree{}},
+		"config.go":     &bintree{configConfigGo, map[string]*bintree{}},
 		"inMemory.json": &bintree{configInmemoryJson, map[string]*bintree{}},
-		"local.json": &bintree{configLocalJson, map[string]*bintree{}},
+		"local.json":    &bintree{configLocalJson, map[string]*bintree{}},
 	}},
 }}
 
@@ -280,4 +281,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -107,10 +107,10 @@ func (r *simpleRunner) updateStatus(newStatus runner.ProcessStatus) (runner.Proc
 	}
 
 	if newStatus.State.IsDone() {
-		if oldStatus.StdoutRef != "" && newStatus.StdoutRef == "" {
+		if newStatus.StdoutRef == "" {
 			newStatus.StdoutRef = oldStatus.StdoutRef
 		}
-		if oldStatus.StderrRef != "" && newStatus.StderrRef == "" {
+		if newStatus.StderrRef == "" {
 			newStatus.StderrRef = oldStatus.StderrRef
 		}
 
@@ -140,7 +140,9 @@ func (r *simpleRunner) run(cmd *runner.Command, runId runner.RunId, doneCh chan 
 	case <-doneCh:
 		go func() {
 			<-checkoutDone
-			checkout.Release()
+			if checkout != nil {
+				checkout.Release()
+			}
 		}()
 		return
 	case <-checkoutDone:

--- a/runner/local/simple.go
+++ b/runner/local/simple.go
@@ -93,37 +93,37 @@ func (r *simpleRunner) Erase(runId runner.RunId) error {
 	return nil
 }
 
-func (r *simpleRunner) updateStatus(new runner.ProcessStatus) (runner.ProcessStatus, error) {
+func (r *simpleRunner) updateStatus(newStatus runner.ProcessStatus) (runner.ProcessStatus, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	old, ok := r.runs[new.RunId]
+	oldStatus, ok := r.runs[newStatus.RunId]
 	if !ok {
-		return runner.ProcessStatus{}, fmt.Errorf("cannot find run %v", new.RunId)
+		return runner.ProcessStatus{}, fmt.Errorf("cannot find run %v", newStatus.RunId)
 	}
 
-	if old.State.IsDone() {
-		return old, nil
+	if oldStatus.State.IsDone() {
+		return oldStatus, nil
 	}
 
-	if new.State.IsDone() {
-		if old.StdoutRef != "" && new.StdoutRef == "" {
-			new.StdoutRef = old.StdoutRef
+	if newStatus.State.IsDone() {
+		if oldStatus.StdoutRef != "" && newStatus.StdoutRef == "" {
+			newStatus.StdoutRef = oldStatus.StdoutRef
 		}
-		if old.StderrRef != "" && new.StderrRef == "" {
-			new.StderrRef = old.StderrRef
+		if oldStatus.StderrRef != "" && newStatus.StderrRef == "" {
+			newStatus.StderrRef = oldStatus.StderrRef
 		}
 
 		// We are ending the running task.
 		// depend on the invariant that there is at most 1 run with !state.IsDone(),
 		// so if we're changing a Process from not Done to Done it must be running
-		log.Printf("local.simpleRunner: run done. %+v", new)
+		log.Printf("local.simpleRunner: run done. %+v", newStatus)
 		close(r.running.doneCh)
 		r.running = nil
 	}
 
-	r.runs[new.RunId] = new
-	return new, nil
+	r.runs[newStatus.RunId] = newStatus
+	return newStatus, nil
 }
 
 // run cmd in the background, writing results to r as id, unless doneCh is closed

--- a/runner/local/simple_test.go
+++ b/runner/local/simple_test.go
@@ -1,4 +1,4 @@
-package local_test
+package local
 
 import (
 	"fmt"
@@ -12,7 +12,6 @@ import (
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
 	"github.com/scootdev/scoot/runner/execer/execers"
-	"github.com/scootdev/scoot/runner/local"
 	"github.com/scootdev/scoot/snapshot/snapshots"
 )
 
@@ -98,11 +97,11 @@ func TestAbort(t *testing.T) {
 }
 
 func complete(exitCode int) runner.ProcessStatus {
-	return runner.CompleteStatus(runner.RunId(""), "", "", exitCode)
+	return runner.CompleteStatus(runner.RunId(""), exitCode)
 }
 
 func running() runner.ProcessStatus {
-	return runner.RunningStatus(runner.RunId(""))
+	return runner.RunningStatus(runner.RunId(""), "", "")
 }
 
 func failed(errorText string) runner.ProcessStatus {
@@ -170,10 +169,10 @@ func newRunner() (runner.Runner, *sync.WaitGroup) {
 		panic(err)
 	}
 
-	outputCreator, err := local.NewOutputCreator(tempDir)
+	outputCreator, err := NewOutputCreator(tempDir)
 	if err != nil {
 		panic(err)
 	}
-	r := local.NewSimpleRunner(ex, snapshots.MakeInvalidCheckouter(), outputCreator)
+	r := NewSimpleRunner(ex, snapshots.MakeInvalidCheckouter(), outputCreator)
 	return r, wg
 }

--- a/runner/status.go
+++ b/runner/status.go
@@ -121,24 +121,23 @@ func BadRequestStatus(runId RunId, err error) (r ProcessStatus) {
 	return r
 }
 
-func RunningStatus(runId RunId) (r ProcessStatus) {
+func RunningStatus(runId RunId, stdoutRef, stderrRef string) (r ProcessStatus) {
 	r.RunId = runId
 	r.State = RUNNING
+	r.StdoutRef = stdoutRef
+	r.StderrRef = stderrRef
 	return r
 }
 
-func CompleteStatus(runId RunId, stdoutRef string, stderrRef string, exitCode int) (r ProcessStatus) {
+func CompleteStatus(runId RunId, exitCode int) (r ProcessStatus) {
 	r.RunId = runId
 	r.State = COMPLETE
-	r.StdoutRef = stdoutRef
-	r.StderrRef = stderrRef
 	r.ExitCode = exitCode
 	return r
 }
 
 func PreparingStatus(runId RunId) (r ProcessStatus) {
-	return ProcessStatus{
-		RunId: runId,
-		State: PREPARING,
-	}
+	r.RunId = runId
+	r.State = PREPARING
+	return r
 }


### PR DESCRIPTION
- runner releases checkout resource if run cancelled before checkout is complete
- some cleanup wrt multiple uses of "run" in simple.go
- runner final updateStatus calls clearer, not relying on inner function logic
- test package rename per convention
- set stdout/stderr refs in run status sooner, and preserve them if status updated later

Main issue was IDd via code inspection - thinking about how to implement positive/negative tests to verify checkout.Release() calls