### PR TITLE
[workerserver] magic bag updates

### DIFF
--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/config/jsonconfig"
 	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/runner"
+	localrunner "github.com/scootdev/scoot/runner/local"
 	"github.com/scootdev/scoot/snapshot"
 	"github.com/scootdev/scoot/snapshot/snapshots"
 	"github.com/scootdev/scoot/workerapi/server"
@@ -36,8 +38,13 @@ func main() {
 			return endpoints.NewTwitterServer(*httpAddr, s)
 		},
 		func() (*temp.TempDir, error) { return temp.TempDirDefault() },
+
 		func(tmpDir *temp.TempDir) snapshot.Checkouter {
 			return snapshots.MakeTempCheckouter(tmpDir)
+		},
+
+		func(tmpDir *temp.TempDir) (runner.OutputCreator, error) {
+			return localrunner.NewOutputCreator(tmpDir)
 		},
 	)
 

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/config/jsonconfig"
 	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/snapshot"
+	"github.com/scootdev/scoot/snapshot/snapshots"
 	"github.com/scootdev/scoot/workerapi/server"
 )
 
@@ -34,6 +36,9 @@ func main() {
 			return endpoints.NewTwitterServer(*httpAddr, s)
 		},
 		func() (*temp.TempDir, error) { return temp.TempDirDefault() },
+		func(tmpDir *temp.TempDir) snapshot.Checkouter {
+			return snapshots.MakeTempCheckouter(tmpDir)
+		},
 	)
 
 	server.RunServer(bag, schema, configText)

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -11,11 +11,7 @@ import (
 	"github.com/scootdev/scoot/common/endpoints"
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/config/jsonconfig"
-	"github.com/scootdev/scoot/os/temp"
-	"github.com/scootdev/scoot/runner"
-	localrunner "github.com/scootdev/scoot/runner/local"
-	"github.com/scootdev/scoot/snapshot"
-	"github.com/scootdev/scoot/snapshot/snapshots"
+
 	"github.com/scootdev/scoot/workerapi/server"
 )
 
@@ -36,15 +32,6 @@ func main() {
 		func() (thrift.TServerTransport, error) { return thrift.NewTServerSocket(*thriftAddr) },
 		func(s stats.StatsReceiver) *endpoints.TwitterServer {
 			return endpoints.NewTwitterServer(*httpAddr, s)
-		},
-		func() (*temp.TempDir, error) { return temp.TempDirDefault() },
-
-		func(tmpDir *temp.TempDir) snapshot.Checkouter {
-			return snapshots.MakeTempCheckouter(tmpDir)
-		},
-
-		func(tmpDir *temp.TempDir) (runner.OutputCreator, error) {
-			return localrunner.NewOutputCreator(tmpDir)
 		},
 	)
 

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -7,7 +7,6 @@ import (
 	"github.com/scootdev/scoot/common/endpoints"
 	"github.com/scootdev/scoot/config/jsonconfig"
 	"github.com/scootdev/scoot/ice"
-	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
 	"github.com/scootdev/scoot/runner/execer"
 	"github.com/scootdev/scoot/runner/execer/execers"
@@ -32,6 +31,7 @@ func makeServers(thrift thrift.TServer, http *endpoints.TwitterServer) servers {
 // - *endpoints.TwitterServer
 // - *temp.TempDir
 // - snapshot.Checkouter
+// - runner.OutputCreator
 // these should be added by callers before invoking RunServer
 func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 	bag := ice.NewMagicBag()
@@ -46,10 +46,6 @@ func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 
 		func() execer.Execer {
 			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(nil), osexec.NewExecer())
-		},
-
-		func(tmpDir *temp.TempDir) (runner.OutputCreator, error) {
-			return localrunner.NewOutputCreator(tmpDir)
 		},
 
 		func(


### PR DESCRIPTION
Updating the default magic bag to include all defaults, main.go should override the ones it want's to use.  

tested via 
go run ./binaries/setup-cloud-scoot/main.go --strategy local.local
go run ./binaries/scootapi/main.go run_smoke_test