### PR TITLE
[Scheduler] Adding timeout to tasks

### DIFF
--- a/binaries/scheduler/config/config.go
+++ b/binaries/scheduler/config/config.go
@@ -69,7 +69,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _configLocalLocal = []byte("\x1f\x8b\x08\x00\x00\x09\x6e\x88\x00\xff\xaa\xe6\x52\x50\x50\x72\xce\x29\x2d\x2e\x49\x2d\x52\xb2\x52\x00\x71\x81\x02\x21\x95\x05\xa9\x40\x9e\x52\x4e\x7e\x72\x62\x8e\x12\x50\xac\x56\x07\xa4\x2e\x3c\xbf\x28\x3b\xb5\xa8\x18\x53\x5d\x51\x41\x32\x58\x15\x57\x2d\x20\x00\x00\xff\xff\x03\xdc\x1c\x93\x50\x00\x00\x00")
+var _configLocalLocal = []byte("\x1f\x8b\x08\x00\x00\x09\x6e\x88\x00\xff\xaa\xe6\x52\x50\x50\x72\xce\x29\x2d\x2e\x49\x2d\x52\xb2\x52\x00\x71\x81\x02\x21\x95\x05\xa9\x40\x9e\x52\x4e\x7e\x72\x62\x8e\x12\x50\xac\x56\x07\xa4\x2e\x3c\xbf\x28\x3b\xb5\xa8\x18\x53\x5d\x51\x41\xb2\x92\x0e\x44\x28\x20\x3f\x27\x27\x33\x2f\x3d\x20\xb5\x28\x33\x3f\x05\x24\x67\x64\x6a\x90\x5b\x0c\x93\x75\xcd\x4b\xcb\x2f\x4a\x4e\x0d\x49\x2c\xce\x0e\xc9\xcc\x4d\xcd\x2f\x2d\x01\x2a\x29\x29\x2a\x4d\x85\xca\xa3\x4a\x28\x19\x1b\xe4\x82\x6d\xe7\xaa\x05\x04\x00\x00\xff\xff\x01\x2a\xa5\x49\xa8\x00\x00\x00")
 
 func configLocalLocalBytes() ([]byte, error) {
 	return bindataRead(
@@ -84,7 +84,7 @@ func configLocalLocal() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/local.local", size: 80, mode: os.FileMode(420), modTime: time.Unix(1475008760, 0)}
+	info := bindataFileInfo{name: "config/local.local", size: 168, mode: os.FileMode(420), modTime: time.Unix(1477000545, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func configLocalMemory() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/local.memory", size: 60, mode: os.FileMode(420), modTime: time.Unix(1475008760, 0)}
+	info := bindataFileInfo{name: "config/local.memory", size: 60, mode: os.FileMode(420), modTime: time.Unix(1476735684, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"config/local.local":  configLocalLocal,
+	"config/local.local": configLocalLocal,
 	"config/local.memory": configLocalMemory,
 }
 
@@ -204,10 +204,9 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"config": &bintree{nil, map[string]*bintree{
-		"local.local":  &bintree{configLocalLocal, map[string]*bintree{}},
+		"local.local": &bintree{configLocalLocal, map[string]*bintree{}},
 		"local.memory": &bintree{configLocalMemory, map[string]*bintree{}},
 	}},
 }}
@@ -258,3 +257,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/binaries/scheduler/config/local.local
+++ b/binaries/scheduler/config/local.local
@@ -3,6 +3,9 @@
     "Type": "local"
   },
   "Workers": {
-    "Type": "rpc"
+    "Type": "rpc",
+    "PollingPeriod": "250ms",
+    "EnforceTaskTimeout": true,
+    "TaskTimeout": "30m"
   }
 }

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -19,7 +19,7 @@ import (
 var thriftAddr = flag.String("thrift_addr", "localhost:9090", "Bind address for api server.")
 var httpAddr = flag.String("http_addr", "localhost:9091", "port to serve http on")
 
-var configFlag = flag.String("config", "local.inmemory", "Scheduler Config (either a filename like local.inmemory or JSON text")
+var configFlag = flag.String("config", "local.memory", "Scheduler Config (either a filename like local.inmemory or JSON text")
 
 func main() {
 	flag.Parse()

--- a/sched/worker/workers/polling.go
+++ b/sched/worker/workers/polling.go
@@ -9,27 +9,57 @@ import (
 )
 
 // NewPollingWorker creates a PollingWorker
-func NewPollingWorker(runner runner.Runner, period time.Duration) worker.Worker {
-	return &PollingWorker{runner, period}
+func NewPollingWorker(
+	runner runner.Runner,
+	period time.Duration) worker.Worker {
+	return NewPollingWorkerWithTimeout(runner, period, false, 0*time.Minute)
+}
+
+// Creates a New Polling Worker which enforces a Timeout on Tasks
+func NewPollingWorkerWithTimeout(
+	runner runner.Runner,
+	period time.Duration,
+	enforceTimout bool,
+	timeout time.Duration) worker.Worker {
+	return &PollingWorker{
+		runner:         runner,
+		pollingPeriod:  period,
+		enforceTimeout: enforceTimout,
+		timeout:        timeout,
+	}
 }
 
 // PollingWorker acts as a Worker by polling the underlying runner every period
 type PollingWorker struct {
-	runner runner.Runner
-	period time.Duration
+	runner         runner.Runner
+	pollingPeriod  time.Duration
+	enforceTimeout bool
+	timeout        time.Duration
 }
 
 func (r *PollingWorker) RunAndWait(task sched.TaskDefinition) (runner.ProcessStatus, error) {
+	// schedule the task
 	status, err := r.runner.Run(&task.Command)
 	if err != nil {
 		return status, err
 	}
+
+	timeSpent := 0 * time.Second
 	id := status.RunId
-	for {
+
+	// Periodically check in with the worker to get a task update
+	for !r.enforceTimeout || (r.enforceTimeout && timeSpent < r.timeout) {
+		time.Sleep(r.pollingPeriod)
+		timeSpent += r.pollingPeriod
+
 		status, err = r.runner.Status(id)
 		if err != nil || status.State.IsDone() {
 			return status, err
 		}
-		time.Sleep(r.period)
 	}
+
+	// The Task took to long to run. Tell the runner to abort before returning
+	status.State = runner.TIMEDOUT
+	_, err = r.runner.Abort(status.RunId)
+	return status, err
 }


### PR DESCRIPTION
We are running into problems testing targets in source.  Some go off and never complete.  Adding a configurable timeout via the scheduler on tasks.  Once the timeout is reached the scheduler will mark the task as completed, but it will be marked with Status TIMEDOUT.  

* I also made the Polling Period Configurable while I was in that code.  
* fixed default config name in scheduler main.go since that never got updated with @dbentley changes.
* Renamed MakeRPCWorkerFactory to Create() to be consistent with the rest of the config objects