### PR TITLE
[Sagas] Caitie/file saga log

### DIFF
--- a/saga/saga.go
+++ b/saga/saga.go
@@ -246,6 +246,11 @@ func FatalErr(err error) bool {
 	case InternalLogError:
 		return false
 
+	// SagaLog is in a bad state, this indicates a fatal bug and no more progress
+	// can be made on this saga.
+	case CorruptedSagaLogError:
+		return true
+
 	// unknown error, default to retryable.
 	default:
 		return true

--- a/saga/saga_test.go
+++ b/saga/saga_test.go
@@ -342,3 +342,10 @@ func TestFatalError_InternalLogError(t *testing.T) {
 		t.Error("Exepected InternalLogError to not be a FatalE Error")
 	}
 }
+
+func TestFatalError_CorruptedSagaLogError(t *testing.T) {
+	err := NewCorruptedSagaLogError("123", "corrupted sagalog")
+	if !FatalErr(err) {
+		t.Error("Expected CorruptedSagaLog to be a Fatal Error")
+	}
+}

--- a/saga/sagalog.go
+++ b/saga/sagalog.go
@@ -42,16 +42,18 @@ type SagaLog interface {
 // that the data stored in the sagalog for a specified saga
 // is corrupted and unrecoverable.
 type CorruptedSagaLogError struct {
-	s string
+	msg string
+	id  string
 }
 
 func (e CorruptedSagaLogError) Error() string {
-	return e.s
+	return fmt.Sprintf("SagaLog for %v has been corrupted, Error: %v", e.id, e.msg)
 }
 
 func NewCorruptedSagaLogError(sagaId string, msg string) error {
 	return CorruptedSagaLogError{
-		s: fmt.Sprintf("SagaLog for %v has been corrupted, Error: %v", sagaId, msg),
+		msg: msg,
+		id:  sagaId,
 	}
 }
 

--- a/saga/sagalog.go
+++ b/saga/sagalog.go
@@ -2,6 +2,10 @@ package saga
 
 //go:generate mockgen -source=sagalog.go -package=saga -destination=sagalog_mock.go
 
+import (
+	"fmt"
+)
+
 /*
  *  SagaLog Interface, Implemented
  */
@@ -32,6 +36,23 @@ type SagaLog interface {
 	 * Returns an error if it fails.
 	 */
 	GetActiveSagas() ([]string, error)
+}
+
+// CorruptedSagaLogError this is a critical error specifies
+// that the data stored in the sagalog for a specified saga
+// is corrupted and unrecoverable.
+type CorruptedSagaLogError struct {
+	s string
+}
+
+func (e CorruptedSagaLogError) Error() string {
+	return e.s
+}
+
+func NewCorruptedSagaLogError(sagaId string, msg string) error {
+	return CorruptedSagaLogError{
+		s: fmt.Sprintf("SagaLog for %v has been corrupted, Error: %v", sagaId, msg),
+	}
 }
 
 // InvalidRequestError should be returned by the SagaLog

--- a/saga/sagalogs/file_saga_log.go
+++ b/saga/sagalogs/file_saga_log.go
@@ -76,7 +76,7 @@ func (log *fileSagaLog) getSagaLogFileName(sagaId string) string {
 }
 
 // Returns the name of the file to store task data in
-// SagaId for the saga
+// SagaId for the saga.  Not deterministic.
 // TaskId corresponding to taskdata
 // SagaMessageType type of SagaMessage
 func (log *fileSagaLog) createTaskDataFileName(
@@ -93,6 +93,8 @@ func (log *fileSagaLog) createTaskDataFileName(
 	)
 }
 
+// Returns the name of the file to store Job Data in based on the
+// SagaId.  Not deterministic.
 func (log *fileSagaLog) createJobDataFileName(sagaId string) string {
 	//format sagaDir/StartSagaData_timestamp
 	return fmt.Sprintf(
@@ -101,11 +103,6 @@ func (log *fileSagaLog) createJobDataFileName(sagaId string) string {
 		time.Now().Format(time.StampNano),
 	)
 }
-
-//TODO: all the writers, write partial messages.  Ideally
-// we'd like the write to succeed or not, if something goes wrong
-// then we may have part of a message written.
-// Create message to write, and only do oen write
 
 // Log a Start Saga Message message to the log.
 // Returns an error if it fails.

--- a/saga/sagalogs/file_saga_log.go
+++ b/saga/sagalogs/file_saga_log.go
@@ -251,7 +251,6 @@ func (log *fileSagaLog) GetMessages(sagaId string) ([]saga.SagaMessage, error) {
 // Returns and error otherwise
 func parseMessage(sagaId string, scanner *bufio.Scanner) (saga.SagaMessage, error) {
 
-	fmt.Println("Parse Message of Type:", scanner.Text())
 	switch scanner.Text() {
 
 	// Parse Start Saga Message

--- a/saga/sagalogs/file_saga_log.go
+++ b/saga/sagalogs/file_saga_log.go
@@ -1,0 +1,315 @@
+package sagalogs
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/scootdev/scoot/saga"
+)
+
+// Writes Saga Log to file system.  Not durable beyond machine failure
+// Sagas are stored in a directory.  Each file contains the log of
+// one saga.
+
+// StartSaga Message
+// StartSaga \n
+// job data \n
+
+// StartTask Message
+// StartTask \n
+// taskId \n
+// taskData \n
+
+// EndTask Message
+// EndTask \n
+// taskId \n
+// taskData \n
+
+// AbortSaga Message
+// AbortSaga \n
+
+// StartCompTask Message
+// StartCompTask \n
+// taskId \n
+// taskData \n
+
+// EndCompTask Message
+// EndComptTask \n
+// taskId \n
+// taskData \n
+
+// EndSaga Message
+// EndSaga
+type fileSagaLog struct {
+	dirName string
+}
+
+// Creates a FileSagaLog with files stored at the specified directory
+// If the directory does not exist it will create it.
+func MakeFileSagaLog(dirName string) (*fileSagaLog, error) {
+
+	if _, err := os.Stat(dirName); err != nil {
+		if os.IsNotExist(err) {
+			os.Mkdir(dirName, 0777)
+		} else {
+			return nil, err
+		}
+	}
+
+	return &fileSagaLog{
+		dirName: dirName,
+	}, nil
+}
+
+func (log *fileSagaLog) getFileName(sagaId string) string {
+	return fmt.Sprintf("%v/%v", log.dirName, sagaId)
+}
+
+//TODO: all the writers, write partial messages.  Ideally
+// we'd like the write to succeed or not, if something goes wrong
+// then we may have part of a message written.
+// Create message to write, and only do oen write
+
+// Log a Start Saga Message message to the log.
+// Returns an error if it fails.
+func (log *fileSagaLog) StartSaga(sagaId string, job []byte) error {
+
+	var file *os.File
+	var err error
+	fileName := log.getFileName(sagaId)
+
+	// Get File Handle for Saga Create it if it doesn't exist
+	if _, err = os.Stat(fileName); err != nil {
+		if os.IsNotExist(err) {
+			file, err = os.Create(fileName)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	} else {
+		fmt.Println("Opening Already Existing File")
+		file, err = os.OpenFile(fileName, os.O_APPEND|os.O_RDWR, 0777)
+		if err != nil {
+			return err
+		}
+	}
+	defer file.Close()
+
+	msg := append([]byte(fmt.Sprintf("%v\n", saga.StartSaga.String())), job...)
+	msg = append(msg, []byte("\n")...)
+
+	_, err = file.Write(msg)
+	if err != nil {
+		return err
+	}
+
+	file.Sync()
+	return nil
+}
+
+//
+// Update the State of the Saga by Logging a message.
+// Returns an error if it fails.
+//
+func (log *fileSagaLog) LogMessage(message saga.SagaMessage) error {
+	var file *os.File
+	var err error
+	fileName := log.getFileName(message.SagaId)
+
+	// Get file handle for Saga if it doesn't exist return error,
+	// Saga wasn't started
+	if _, err = os.Stat(fileName); err != nil {
+		return err
+	} else {
+		file, err = os.OpenFile(fileName, os.O_APPEND|os.O_RDWR, 0777)
+		if err != nil {
+			return err
+		}
+	}
+	defer file.Close()
+
+	// Write MessageType
+	msg := []byte(fmt.Sprintf("%v\n", message.MsgType.String()))
+
+	// If its a Task Type Write the TaskId and Data
+	if message.MsgType == saga.StartTask ||
+		message.MsgType == saga.EndTask ||
+		message.MsgType == saga.StartCompTask ||
+		message.MsgType == saga.EndCompTask {
+
+		msg = append(msg, []byte(fmt.Sprintf("%v\n", message.TaskId))...)
+		msg = append(msg, message.Data...)
+		msg = append(msg, []byte("\n")...)
+	}
+
+	_, err = file.Write(msg)
+	if err != nil {
+		return err
+	}
+
+	file.Sync()
+	return nil
+}
+
+//
+// Returns all of the messages logged so far for the
+// specified saga.
+//
+func (log *fileSagaLog) GetMessages(sagaId string) ([]saga.SagaMessage, error) {
+	fileName := log.getFileName(sagaId)
+	fmt.Printf("FileName: %v", fileName)
+	file, err := os.Open(fmt.Sprintf(fileName))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	msgs := make([]saga.SagaMessage, 0)
+	scanner := bufio.NewScanner(file)
+	nextToken := scanner.Scan()
+
+	for nextToken == true {
+		msg, err := parseMessage(sagaId, scanner)
+		if err != nil {
+			return nil, err
+		}
+
+		msgs = append(msgs, msg)
+		nextToken = scanner.Scan()
+	}
+
+	return msgs, nil
+}
+
+// Helper Function that Parses a SagaMessage.  Returns a message if succesfully parsed
+// Returns and error otherwise
+func parseMessage(sagaId string, scanner *bufio.Scanner) (saga.SagaMessage, error) {
+
+	fmt.Println("Parse Message of Type:", scanner.Text())
+	switch scanner.Text() {
+
+	// Parse Start Saga Message
+	case saga.StartSaga.String():
+		if ok := scanner.Scan(); !ok {
+			return saga.SagaMessage{}, saga.NewCorruptedSagaLogError(
+				sagaId,
+				fmt.Sprintf("Error Parsing SagaLog expected Data after StartSaga message.  Error: %v",
+					createUnexpectedScanEndMsg(scanner)),
+			)
+		}
+		return saga.MakeStartSagaMessage(sagaId, scanner.Bytes()), nil
+
+		// Parse End Saga Message
+	case saga.EndSaga.String():
+		return saga.MakeEndSagaMessage(sagaId), nil
+
+		// Parse Abort Saga Message
+	case saga.AbortSaga.String():
+		return saga.MakeAbortSagaMessage(sagaId), nil
+
+		// Parse Start Task Message
+	case saga.StartTask.String():
+		taskId, data, err := parseTask(sagaId, scanner)
+		if err != nil {
+			return saga.SagaMessage{}, err
+		}
+		return saga.MakeStartTaskMessage(sagaId, taskId, data), nil
+
+		// Parse End Task Message
+	case saga.EndTask.String():
+		taskId, data, err := parseTask(sagaId, scanner)
+		if err != nil {
+			return saga.SagaMessage{}, err
+		}
+		return saga.MakeEndTaskMessage(sagaId, taskId, data), nil
+
+		// Parse Start Comp Task Message
+	case saga.StartCompTask.String():
+		taskId, data, err := parseTask(sagaId, scanner)
+		if err != nil {
+			return saga.SagaMessage{}, err
+		}
+		return saga.MakeStartCompTaskMessage(sagaId, taskId, data), nil
+
+		// Parse End Comp Task Message
+	case saga.EndCompTask.String():
+		taskId, data, err := parseTask(sagaId, scanner)
+		if err != nil {
+			return saga.SagaMessage{}, err
+		}
+		return saga.MakeEndCompTaskMessage(sagaId, taskId, data), nil
+
+		// Unrecognized Message
+	default:
+		return saga.SagaMessage{}, saga.NewCorruptedSagaLogError(
+			sagaId,
+			fmt.Sprintf("Error Parsing SagaLog unrecognized message type, %v", scanner.Text()),
+		)
+	}
+}
+
+// Helper function that parses a task message, StartTask, EndTask, StartCompTask,
+// EndCompTasks.  Message is of structure
+// line1: MessageType
+// line2: TaskId
+// line3: TaskData
+// Returns a tuple of TaskId, TaskData, Error
+func parseTask(sagaId string, scanner *bufio.Scanner) (string, []byte, error) {
+	if ok := scanner.Scan(); !ok {
+		return "", nil,
+			saga.NewCorruptedSagaLogError(
+				sagaId,
+				fmt.Sprintf("Error Parsing SagaLog expected TaskId, Error: %v",
+					createUnexpectedScanEndMsg(scanner)),
+			)
+	}
+	taskId := scanner.Text()
+	if ok := scanner.Scan(); !ok {
+		return "", nil,
+			saga.NewCorruptedSagaLogError(
+				sagaId,
+				fmt.Sprintf("Error Parsing SagaLog expected Data, Error: %v",
+					createUnexpectedScanEndMsg(scanner)),
+			)
+	}
+	data := scanner.Bytes()
+
+	return taskId, data, nil
+}
+
+func createUnexpectedScanEndMsg(scanner *bufio.Scanner) string {
+	var errMsg string
+	if scanner.Err() != nil {
+		errMsg = scanner.Err().Error()
+	} else {
+		errMsg = "Unexpected EOF"
+	}
+	return errMsg
+}
+
+//
+// Returns a list of all in progress sagaIds.
+// This MUST include all not completed sagaIds.
+// It may also included completed sagas
+// Returns an error if it fails.
+//
+// This is a very dumb implementation currently just returns
+// a list of all sagas.  This can be improved with an index
+//
+func (log *fileSagaLog) GetActiveSagas() ([]string, error) {
+	files, err := ioutil.ReadDir(log.dirName)
+	if err != nil {
+		return nil, err
+	}
+
+	sagaIds := make([]string, len(files), len(files))
+	for i, file := range files {
+		sagaIds[i] = file.Name()
+	}
+
+	return sagaIds, nil
+}

--- a/saga/sagalogs/file_saga_log_test.go
+++ b/saga/sagalogs/file_saga_log_test.go
@@ -2,8 +2,8 @@ package sagalogs
 
 import (
 	"bytes"
-	"fmt"
 	"os"
+	"path"
 	"reflect"
 	"testing"
 
@@ -11,11 +11,7 @@ import (
 )
 
 func getDirName() string {
-	path, err := os.Getwd()
-	if err != nil {
-		panic(fmt.Sprintf("Could not get path.  Error: %v", err))
-	}
-	return fmt.Sprintf("%v/%v", path, "sagas")
+	return path.Join(os.TempDir(), "sagas")
 }
 
 // Removes the sagas directory and all files created during
@@ -42,6 +38,8 @@ func isSagaInActiveList(sagaId string, slog saga.SagaLog) bool {
 }
 
 func TestStartSaga(t *testing.T) {
+	defer testCleanup(t)
+
 	dirName := getDirName()
 	sagaId := "saga1"
 
@@ -76,11 +74,11 @@ func TestStartSaga(t *testing.T) {
 	if !isSagaInActiveList(sagaId, slog) {
 		t.Errorf("Expected Saga to be in active list")
 	}
-
-	testCleanup(t)
 }
 
 func TestStartSaga_SagaFileAlreadyExists(t *testing.T) {
+	defer testCleanup(t)
+
 	dirName := getDirName()
 	sagaId := "start_saga_called_twice"
 	data1 := []byte{0, 1, 2, 3, 4, 5}
@@ -105,11 +103,11 @@ func TestStartSaga_SagaFileAlreadyExists(t *testing.T) {
 	if !isSagaInActiveList(sagaId, slog) {
 		t.Errorf("Expected Saga to be in Active List")
 	}
-
-	testCleanup(t)
 }
 
 func TestFullSaga(t *testing.T) {
+	defer testCleanup(t)
+
 	dirName := getDirName()
 	sagaId := "fullsaga"
 
@@ -157,6 +155,4 @@ func TestFullSaga(t *testing.T) {
 				loggedMsgs[j], rtnMsg)
 		}
 	}
-
-	testCleanup(t)
 }

--- a/saga/sagalogs/file_saga_log_test.go
+++ b/saga/sagalogs/file_saga_log_test.go
@@ -1,0 +1,162 @@
+package sagalogs
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/scootdev/scoot/saga"
+)
+
+func getDirName() string {
+	path, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Sprintf("Could not get path.  Error: %v", err))
+	}
+	return fmt.Sprintf("%v/%v", path, "sagas")
+}
+
+// Removes the sagas directory and all files created during
+// a test execution
+func testCleanup(t *testing.T) {
+	err := os.RemoveAll(getDirName())
+	if err != nil {
+		t.Errorf("error cleaning up saga directory, %v", err)
+	}
+}
+
+// returns true if its in the active saga list, false otherwise
+func isSagaInActiveList(sagaId string, slog saga.SagaLog) bool {
+	// check its in active sagas
+	activeSagas, _ := slog.GetActiveSagas()
+
+	for _, activeSagaId := range activeSagas {
+		if activeSagaId == sagaId {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestStartSaga(t *testing.T) {
+	dirName := getDirName()
+	sagaId := "saga1"
+
+	slog, err := MakeFileSagaLog(dirName)
+	if err != nil {
+		t.Errorf("Unexpected Error Returned %v", err)
+	}
+
+	data := []byte{0, 1, 2, 3, 4, 5}
+	err = slog.StartSaga(sagaId, data)
+	if err != nil {
+		t.Errorf("Unexpected Error starting Saga")
+	}
+
+	msgs, err := slog.GetMessages(sagaId)
+	if err != nil {
+		t.Errorf("Unexpected Error Getting Messages %v", err)
+	}
+
+	if len(msgs) != 1 {
+		t.Errorf("Expected 1 message for saga, not %v, Messages: %+v", len(msgs), msgs)
+	}
+
+	if msgs[0].MsgType != saga.StartSaga {
+		t.Errorf("Unexpected Message Type.  Expected: StartSaga, Actual: %v", msgs[0].MsgType)
+	}
+
+	if !bytes.Equal(data, msgs[0].Data) {
+		t.Errorf("Expected Start Saga Message Data to be: %v, Actual: %v", data, msgs[0].Data)
+	}
+
+	if !isSagaInActiveList(sagaId, slog) {
+		t.Errorf("Expected Saga to be in active list")
+	}
+
+	testCleanup(t)
+}
+
+func TestStartSaga_SagaFileAlreadyExists(t *testing.T) {
+	dirName := getDirName()
+	sagaId := "start_saga_called_twice"
+	data1 := []byte{0, 1, 2, 3, 4, 5}
+	data2 := []byte{6, 7, 8, 9}
+
+	slog, _ := MakeFileSagaLog(dirName)
+	slog.StartSaga(sagaId, data1)
+	err := slog.StartSaga(sagaId, data2)
+	if err != nil {
+		t.Errorf("Unexpected Error Calling Start Saga Twice %v", err)
+	}
+
+	msgs, err := slog.GetMessages(sagaId)
+	if err != nil {
+		t.Errorf("Unexpected Error Getting Messages %v", err)
+	}
+
+	if len(msgs) != 2 {
+		t.Errorf("Expected 1 message for saga, not %v, Messages: %+v", len(msgs), msgs)
+	}
+
+	if !isSagaInActiveList(sagaId, slog) {
+		t.Errorf("Expected Saga to be in Active List")
+	}
+
+	testCleanup(t)
+}
+
+func TestFullSaga(t *testing.T) {
+	dirName := getDirName()
+	sagaId := "fullsaga"
+
+	slog, _ := MakeFileSagaLog(dirName)
+	jobData := []byte{0, 1, 2, 3, 4, 5}
+	slog.StartSaga(sagaId, jobData)
+
+	loggedMsgs := []saga.SagaMessage{
+		saga.MakeStartSagaMessage(sagaId, jobData),
+		saga.MakeStartTaskMessage(sagaId, "task1", []byte("run task 1")),
+		saga.MakeEndTaskMessage(sagaId, "task1", []byte("success")),
+		saga.MakeAbortSagaMessage(sagaId),
+		saga.MakeStartCompTaskMessage(sagaId, "task1", []byte("rollingback task1")),
+		saga.MakeEndCompTaskMessage(sagaId, "task1", []byte("finished rollingback task1")),
+		saga.MakeEndSagaMessage(sagaId),
+	}
+
+	for i, msg := range loggedMsgs {
+		// skip start saga message we already did it
+		if i == 0 {
+			continue
+		}
+
+		err := slog.LogMessage(msg)
+		if err != nil {
+			t.Fatalf("Unexpected Error Logging Msg: %+v, Error: %v", msg, err)
+		}
+
+	}
+
+	rtnMsgs, err := slog.GetMessages(sagaId)
+	if err != nil {
+		t.Fatalf("Unexpected Error returned from GetMessages. %v", err)
+	}
+
+	if len(rtnMsgs) != len(loggedMsgs) {
+		t.Fatalf("Expected GetMessages to return %v messages.  Actual %v.  Msgs %+v",
+			len(loggedMsgs), len(rtnMsgs), rtnMsgs)
+	}
+
+	// we expect the messages to be returned in the same order they are logged
+	for j, rtnMsg := range rtnMsgs {
+		if !reflect.DeepEqual(loggedMsgs[j], rtnMsg) {
+			t.Errorf("Expected Logged Message and Returned Message to be Equal.  Expected %v, Actual %v",
+				loggedMsgs[j], rtnMsg)
+		}
+	}
+
+	testCleanup(t)
+}


### PR DESCRIPTION
Create a file based saga log.  This is to enable testing of SagaRecovery, currently InMemorySaga does not survive beyond process restart.  File Based SagaLog will be durable beyond process restart , but not beyond machine failure. 

Added CorruptedSagaLog as a Fatal Error.  This should not happen in production unless we did something really wrong (made a breaking change), but allows us to easily detect via test cases if our parsing and reading of the SagaLog files works correctly.