### PR TITLE
retry smoke test & dial update

### DIFF
--- a/scootapi/client/cli.go
+++ b/scootapi/client/cli.go
@@ -49,8 +49,9 @@ func NewSimpleCLIClient(d dialer.Dialer) (CLIClient, error) {
 }
 
 func (c *simpleCLIClient) Dial() error {
-	// Always recreate a connection.  This way if something went wrong with
-	// the previous connection we don't have a clean one.
+	// Always create a new connection, so that we have a clean one
+	// If we reuse connections and something goes wrong (pipe breaks etc...)
+	// there is no way to recreate it.
 	return c.createScootClient()
 }
 

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -60,6 +60,11 @@ func (r *smokeTestRunner) run(numJobs int, timeout time.Duration) error {
 		if err != nil {
 			return err
 		}
+		// retry starting job until it succeeds
+		for err != nil {
+			log.Printf("Error Starting Job: Retrying %v", err)
+			id, err = r.generateAndStartJob()
+		}
 		jobs[id] = nil
 	}
 
@@ -75,7 +80,12 @@ func (r *smokeTestRunner) generateAndStartJob() (string, error) {
 
 	job := testhelpers.GenJobDefinition(rng)
 	jobId, err := r.cl.scootClient.RunJob(job)
-	return jobId.ID, err
+
+	if err == nil {
+		return jobId.ID, nil
+	} else {
+		return "", err
+	}
 }
 
 func (r *smokeTestRunner) waitForJobs(jobs map[string]*scoot.JobStatus, timeout time.Duration) error {
@@ -88,9 +98,13 @@ func (r *smokeTestRunner) waitForJobs(jobs map[string]*scoot.JobStatus, timeout 
 		done := true
 		for k, _ := range jobs {
 			d, err := r.updateJobStatus(k, jobs)
+
+			// if there is an error just continue
 			if err != nil {
-				return err
+				log.Printf("Error: Updating Job Status ID: %v will retry later, Error: %v", k, err)
+				d = false
 			}
+
 			done = done && d
 		}
 		if done {

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -57,9 +57,6 @@ func (r *smokeTestRunner) run(numJobs int, timeout time.Duration) error {
 
 	for i := 0; i < numJobs; i++ {
 		id, err := r.generateAndStartJob()
-		if err != nil {
-			return err
-		}
 		// retry starting job until it succeeds
 		for err != nil {
 			log.Printf("Error Starting Job: Retrying %v", err)


### PR DESCRIPTION
Currently SmokeTest fails as soon as the scheduler dies.  Any call to ScootAPI that fails results in the test failing.  However, we want to test scheduler restarts, which means some calls may fail.

This update allows failures to the scheduler to be retried.  Currently by reusing the ScootApiClient associated with the Dialer, a broken pipe will be broken forever so Dial() needs to create a new scootClient connection on every call