### PR TITLE
scootapi/client - fix client addr flag parsing

### DIFF
--- a/binaries/scheduler/config/config.go
+++ b/binaries/scheduler/config/config.go
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"config/local.local": configLocalLocal,
+	"config/local.local":  configLocalLocal,
 	"config/local.memory": configLocalMemory,
 }
 
@@ -204,9 +204,10 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"config": &bintree{nil, map[string]*bintree{
-		"local.local": &bintree{configLocalLocal, map[string]*bintree{}},
+		"local.local":  &bintree{configLocalLocal, map[string]*bintree{}},
 		"local.memory": &bintree{configLocalMemory, map[string]*bintree{}},
 	}},
 }}
@@ -257,4 +258,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/scootapi/client/cli.go
+++ b/scootapi/client/cli.go
@@ -27,6 +27,7 @@ func (c *simpleCLIClient) Exec() error {
 
 func NewSimpleCLIClient(d dialer.Dialer) (CLIClient, error) {
 	c := &simpleCLIClient{}
+	c.dial = d
 
 	c.rootCmd = &cobra.Command{
 		Use:                "scootapi",


### PR DESCRIPTION
This was broken - the check of the addr flag was being done before cobra had parsed the flags, which meant it always fell through to use ~/.cloudscootaddr