### PR TITLE
scootapi/client - Add default error case to client get_status cmd

### DIFF
--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -39,6 +39,8 @@ func (c *getStatusCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []strin
 		case *scoot.InvalidRequest:
 			return fmt.Errorf("Invalid Request: %v", err.GetMessage())
 		case *scoot.ScootServerError:
+			return fmt.Errorf("Scoot server errors: %v", err.Error())
+		default:
 			return fmt.Errorf("Error getting status: %v", err.Error())
 		}
 	}

--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -39,7 +39,7 @@ func (c *getStatusCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []strin
 		case *scoot.InvalidRequest:
 			return fmt.Errorf("Invalid Request: %v", err.GetMessage())
 		case *scoot.ScootServerError:
-			return fmt.Errorf("Scoot server errors: %v", err.Error())
+			return fmt.Errorf("Scoot server error: %v", err.Error())
 		default:
 			return fmt.Errorf("Error getting status: %v", err.Error())
 		}


### PR DESCRIPTION
scootapi exits 0 when it can't connect.