### PR TITLE
snapshot/git: a few fixes

### DIFF
--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -96,6 +96,10 @@ func (b *bundlestoreBackend) uploadLocalSnapshot(s *localSnapshot, db *DB) (sn s
 
 			mergeBase, err := db.dataRepo.RunSha("merge-base", streamHead, commitSha)
 
+			if mergeBase == commitSha {
+				return &streamSnapshot{sha: commitSha, kind: kindGitCommitSnapshot, streamName: db.stream.cfg.Name}, nil
+			}
+
 			// if err != nil, it just means we don't have a merge-base
 			if err == nil {
 				revList = fmt.Sprintf("%s..%s", mergeBase, bundlestoreTempRef)

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -97,6 +97,10 @@ func (b *bundlestoreBackend) uploadLocalSnapshot(s *localSnapshot, db *DB) (sn s
 			mergeBase, err := db.dataRepo.RunSha("merge-base", streamHead, commitSha)
 
 			if mergeBase == commitSha {
+				// we were asked to ingest a sha that's on the stream,
+				// so we don't have to upload it, just return that snapshot
+				// if we don't do this, then our git bundle create will die
+				// because the bundle would be empty.
 				return &streamSnapshot{sha: commitSha, kind: kindGitCommitSnapshot, streamName: db.stream.cfg.Name}, nil
 			}
 

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -98,6 +98,8 @@ func (b *bundlestoreBackend) uploadLocalSnapshot(s *localSnapshot, db *DB) (sn s
 
 			if mergeBase == commitSha {
 				// we were asked to ingest a sha that's on the stream,
+				// e.g., the user just created a branch and just wants to test
+				// the baseline, and hasn't modified anything yet.
 				// so we don't have to upload it, just return that snapshot
 				// if we don't do this, then our git bundle create will die
 				// because the bundle would be empty.

--- a/snapshot/git/gitdb/create.go
+++ b/snapshot/git/gitdb/create.go
@@ -22,19 +22,19 @@ func (db *DB) ingestDir(dir string) (snapshot, error) {
 	indexFilename := filepath.Join(indexDir.Dir, "index")
 	defer os.RemoveAll(indexDir.Dir)
 
-	extraEnv := []string{"GIT_INDEX_FILE=" + indexFilename, "GIT_WORK_TREE=" + dir}
+	env := append(os.Environ(), "GIT_INDEX_FILE="+indexFilename, "GIT_WORK_TREE="+dir)
 
 	// TODO(dbentley): should we use update-index instead of add? Maybe add looks at repo state
 	// (e.g., HEAD) and we should just use the lower-level plumbing command?
 	cmd := db.dataRepo.Command("add", ".")
-	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Env = env
 	_, err = db.dataRepo.RunCmd(cmd)
 	if err != nil {
 		return nil, err
 	}
 
 	cmd = db.dataRepo.Command("write-tree")
-	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Env = env
 	sha, err := db.dataRepo.RunCmdSha(cmd)
 	if err != nil {
 		return nil, err

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -94,7 +94,7 @@ func TestIngestCommit(t *testing.T) {
 		t.Fatalf("error checking out %v, %v", id2, err)
 	}
 
-	// text contents
+	// test contents
 	if err := assertFileContents(co, "file.txt", "second"); err != nil {
 		t.Fatal(err)
 	}
@@ -337,12 +337,26 @@ func TestBundlestore(t *testing.T) {
 
 	consumerDB := MakeDBFromRepo(consumerDataRepo, fixture.tmp, streamCfg, nil, bundleCfg, AutoUploadBundlestore)
 
+	upstreamMaster, err := fixture.upstream.RunSha("rev-parse", "master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fixture.external.Run("fetch", "upstream"); err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := authorDB.IngestGitCommit(fixture.external, upstreamMaster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	externalCommitID, err := commitText(fixture.external, "bundlestore_first")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	id, err := authorDB.IngestGitCommit(fixture.external, externalCommitID)
+	id, err = authorDB.IngestGitCommit(fixture.external, externalCommitID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -502,6 +516,10 @@ func setup() (f *dbFixture, err error) {
 
 	tags, err := createRepo(tmp, "tags-repo")
 	if err != nil {
+		return nil, err
+	}
+
+	if _, err := external.Run("remote", "add", "upstream", upstream.Dir()); err != nil {
 		return nil, err
 	}
 

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -331,6 +331,7 @@ func TestBundlestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// First, test that if we try and upload something that's already in master, we succeed
 	if _, err := consumerDataRepo.Run("remote", "add", "upstream", fixture.upstream.Dir()); err != nil {
 		t.Fatal(err)
 	}
@@ -351,6 +352,7 @@ func TestBundlestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Now, create a change in external with new contents and upload that
 	externalCommitID, err := commitText(fixture.external, "bundlestore_first")
 	if err != nil {
 		t.Fatal(err)
@@ -366,6 +368,7 @@ func TestBundlestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Now, create a new directory with independent contents and ingest it.
 	tmp, err = fixture.tmp.TempDir("output")
 	if err != nil {
 		t.Fatal(err)
@@ -383,7 +386,7 @@ func TestBundlestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := assertSnapshotContents(authorDB, id, "stdout.txt", "stdout"); err != nil {
+	if err := assertSnapshotContents(consumerDB, id, "stdout.txt", "stdout"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
In bundlestore.go, if the we're asked to ingest a comit that's on the branch
in the stream, then return a snap from the stream (instead of trying to
upload)

create.go: when we were adding env variables to our run of git, we were
actually not using any of the existing environment; oops.