### PR TITLE
added ability to use log.Fatal(), log.Trace() and log.Info().  This i…

### DIFF
--- a/binaries/scheduler/config/config.go
+++ b/binaries/scheduler/config/config.go
@@ -85,7 +85,7 @@ func configConfigGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/config.go", size: 0, mode: os.FileMode(420), modTime: time.Unix(1486507161, 0)}
+	info := bindataFileInfo{name: "config/config.go", size: 0, mode: os.FileMode(420), modTime: time.Unix(1490022286, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -105,7 +105,7 @@ func configLocalLocal() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/local.local", size: 460, mode: os.FileMode(420), modTime: time.Unix(1486507145, 0)}
+	info := bindataFileInfo{name: "config/local.local", size: 460, mode: os.FileMode(420), modTime: time.Unix(1489433454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func configLocalMemory() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/local.memory", size: 312, mode: os.FileMode(420), modTime: time.Unix(1486507155, 0)}
+	info := bindataFileInfo{name: "config/local.memory", size: 312, mode: os.FileMode(420), modTime: time.Unix(1489433454, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -182,8 +182,8 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"config/config.go": configConfigGo,
-	"config/local.local": configLocalLocal,
+	"config/config.go":    configConfigGo,
+	"config/local.local":  configLocalLocal,
 	"config/local.memory": configLocalMemory,
 }
 
@@ -226,10 +226,11 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"config": &bintree{nil, map[string]*bintree{
-		"config.go": &bintree{configConfigGo, map[string]*bintree{}},
-		"local.local": &bintree{configLocalLocal, map[string]*bintree{}},
+		"config.go":    &bintree{configConfigGo, map[string]*bintree{}},
+		"local.local":  &bintree{configLocalLocal, map[string]*bintree{}},
 		"local.memory": &bintree{configLocalMemory, map[string]*bintree{}},
 	}},
 }}
@@ -280,4 +281,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -4,12 +4,12 @@ package main
 
 import (
 	"flag"
-	"log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 
 	"github.com/scootdev/scoot/binaries/scheduler/config"
 	"github.com/scootdev/scoot/common/endpoints"
+	log "github.com/scootdev/scoot/common/logger"
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/config/jsonconfig"
 	"github.com/scootdev/scoot/os/temp"
@@ -42,6 +42,6 @@ func main() {
 		},
 	)
 
-	log.Println("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
+	log.Trace("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/workerserver/config/config.go
+++ b/binaries/workerserver/config/config.go
@@ -84,7 +84,7 @@ func configConfigGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/config.go", size: 0, mode: os.FileMode(420), modTime: time.Unix(1486507161, 0)}
+	info := bindataFileInfo{name: "config/config.go", size: 0, mode: os.FileMode(420), modTime: time.Unix(1490022286, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func configLocalLocal() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/local.local", size: 2, mode: os.FileMode(420), modTime: time.Unix(1478799548, 0)}
+	info := bindataFileInfo{name: "config/local.local", size: 2, mode: os.FileMode(420), modTime: time.Unix(1476913802, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"config/config.go": configConfigGo,
+	"config/config.go":   configConfigGo,
 	"config/local.local": configLocalLocal,
 }
 
@@ -204,9 +204,10 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"config": &bintree{nil, map[string]*bintree{
-		"config.go": &bintree{configConfigGo, map[string]*bintree{}},
+		"config.go":   &bintree{configConfigGo, map[string]*bintree{}},
 		"local.local": &bintree{configLocalLocal, map[string]*bintree{}},
 	}},
 }}
@@ -257,4 +258,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -1,0 +1,169 @@
+/**
+Utility to get the service's logger.  All objects will use GetLogger() to get the logger.
+We are currently using golang's default logger and setting it to write to log.txt in
+a directory created by temp.TempDirDefault()
+
+To add a new logging level <levelX>:
+1. add the <levelX> to the const () declaration
+2. declare a logger for that levelX (see bottom of file)
+3. declare LevelX() and LevelXF() functions matching the Info() and Infof() pattern
+
+*/
+package logger
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	"github.com/scootdev/scoot/os/temp"
+	"runtime/debug"
+	"strings"
+)
+
+const (
+	FATAL_LEVEL = iota
+	TRACE_LEVEL
+	INFO_LEVEL
+)
+
+var mu = &sync.Mutex{}
+
+/**
+Set the log level.  Only messages at or below this level will be printed
+*/
+func SetLevel(l int) {
+	level = l
+}
+
+/**
+functions for printing the different levels.  If we add Debug, Warn etc. add corresponding
+methods here
+*/
+func Info(a ...interface{}) {
+	doPrint(INFO_LEVEL, infoLogger, "", a...)
+}
+
+func Infof(format string, v ...interface{}) {
+	doPrint(INFO_LEVEL, infoLogger, format, v...)
+}
+
+func Trace(a ...interface{}) {
+	doPrint(TRACE_LEVEL, traceLogger, "", a...)
+}
+
+func Tracef(format string, v ...interface{}) {
+	doPrint(TRACE_LEVEL, traceLogger, format, v...)
+}
+
+func Fatal(a ...interface{}) {
+	doPrint(FATAL_LEVEL, fatalLogger, "", a...)
+}
+
+func Fatalf(format string, v ...interface{}) {
+	doPrint(FATAL_LEVEL, fatalLogger, format, v...)
+}
+
+func doPrint(l int, logger *log.Logger, format string, v ...interface{}) {
+	if level >= l {
+		logLine := getLogLine()
+		mu.Lock()
+		defer mu.Unlock()
+		prefix := logger.Prefix()
+		logger.SetPrefix(prefix + logLine + ";")
+		if format != "" {
+			logger.Printf(format, v...)
+
+		} else {
+			logger.Print(v...)
+		}
+		logger.SetPrefix(prefix)
+	}
+}
+
+/**
+get the stack trace line that issued the logger call
+*/
+func getLogLine() string {
+	stack := debug.Stack()
+	lines := strings.Split(string(stack), "\n")
+	foundLoggerBlock := false
+	incr := 1
+	for i := 0; i < len(lines); i = i + incr {
+		if strings.Contains(lines[i], "logger.go:") {
+			foundLoggerBlock = true
+			incr = 2
+			continue
+		}
+		if !foundLoggerBlock {
+			continue
+		}
+		return lines[i]
+	}
+	return ""
+}
+
+var level int = INFO_LEVEL
+
+/*
+the writer is defined here
+*/
+type logWriter struct {
+	machineName string
+	filename    string
+	file        *os.File
+}
+
+var lw = getDefaultLogWriter()
+
+/*
+This section of the code
+creates a log writer that writes to log.txt (in the directory created by temp.TempDirDefault().
+
+We can extend this later to return a writer that implements configurable behavior (eg: specified in a
+property file).  (example: rolling writes, writing to designated file name, screening undesired log
+messages, etc.
+*/
+func getDefaultLogWriter() *logWriter {
+	var tmpDir, err = temp.MakeTempDir(temp.Scoot_tmp_dir_prefix + "log-")
+	if err != nil {
+		log.Panicf("Logger initialization failed creating defaultLogWriter, getting temp dir:%s", err.Error())
+	}
+
+	logFilename := tmpDir.Dir + "/log.txt"
+	file, err := os.OpenFile(logFilename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		log.Panicf("Logger initialization failed opening log file '%s': %s", logFilename, err.Error())
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Panicf("Logger initialization failed getting hostname: %s", err.Error())
+	}
+
+	lw := logWriter{filename: logFilename, file: file, machineName: hostname}
+	return &lw
+}
+
+/**
+write a new line to the log file (automatically append \n)
+*/
+func (w *logWriter) Write(message []byte) (n int, err error) {
+	t := fmt.Sprintf("%s;%s", w.machineName, string(message))
+	return w.file.WriteString(t)
+}
+
+/**
+Returns the filename that the logger is currently using.  (Intended for validation only.)
+*/
+func getLogFilename() string {
+	return lw.filename
+}
+
+/**
+these are the actual loggers with a preset prefix.  They will all write to the same writer.
+*/
+var infoLogger = log.New(lw, "INFO;", log.LstdFlags|log.Lmicroseconds|log.LUTC)
+var traceLogger = log.New(lw, "TRACE;", log.LstdFlags|log.Lmicroseconds|log.LUTC)
+var fatalLogger = log.New(lw, "FATAL;", log.LstdFlags|log.Lmicroseconds|log.LUTC)

--- a/common/logger/logger_test.go
+++ b/common/logger/logger_test.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLogUtils(t *testing.T) {
+
+	Fatal("Fatal message without param")
+	Fatalf("%s, %f", "Fatal message with param", 2.3)
+
+	Info("Info message without param", 8)
+	Infof("Info message with param %d", 10)
+
+	SetLevel(FATAL_LEVEL)
+	Info("Info message without param")
+
+	lf := getLogFilename()
+	fmt.Println("messages written to:", lf)
+
+	file, err := os.Open(lf)
+	if err != nil {
+		t.Fatalf("Couldn't find log file:%s", lf)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	line := scanner.Text()
+
+	if !strings.Contains(line, "Fatal message without param") {
+		t.Errorf("Expected: 'FATAL;<datetime, line number>: Fatal message without param' got '%s' in %s\n", line, lf)
+	}
+	scanner.Scan()
+	line = scanner.Text()
+	if !strings.Contains(line, "Fatal message with param") ||
+		!strings.Contains(line, "FATAL;") {
+		t.Errorf("Expected: 'FATAL;<datetime, line number>:Fatal message with param' got '%s' in %s\n", line, lf)
+	}
+	scanner.Scan()
+	line = scanner.Text()
+	if !strings.Contains(line, "Info message without param8") ||
+		!strings.Contains(line, "INFO;") {
+		t.Errorf("Expected: 'Info message without param8' got '%s' in %s\n", line, lf)
+	}
+	scanner.Scan()
+	line = scanner.Text()
+	if !strings.Contains(line, "Info message with param") ||
+		!strings.Contains(line, "INFO;") {
+		t.Errorf("Expected 'Info message with param' got '%s' in %s\n", line, lf)
+	}
+
+	if scanner.Scan() {
+		line = scanner.Text()
+		t.Errorf("Expected last scan to return false (due to end of text), instead got %s", line)
+	}
+}

--- a/os/temp/temp_dir.go
+++ b/os/temp/temp_dir.go
@@ -14,6 +14,10 @@ import (
 	"github.com/scootdev/scoot/ice"
 )
 
+const (
+	Scoot_tmp_dir_prefix = "scoot-tmp-"
+)
+
 // Create a new TempDir in directory dir with prefix string.
 func NewTempDir(dir, prefix string) (*TempDir, error) {
 	p, err := ioutil.TempDir(dir, prefix)
@@ -56,9 +60,18 @@ func (d *TempDir) TempFile(prefix string) (*os.File, error) {
 
 // TempDirDefault creates a TempDir rooted in the default temp dir
 func TempDirDefault() (*TempDir, error) {
-	tmpDir, err := ioutil.TempDir("", "scoot-tmp-")
+	tmpDir, err := ioutil.TempDir("", Scoot_tmp_dir_prefix)
 	if err != nil {
 		return nil, fmt.Errorf("temp.TempDirDefault: couldn't ioutil.TempDir: %v", err)
+	}
+	return &TempDir{tmpDir}, err
+}
+
+// TempDirDefault creates a TempDir rooted in the default temp dir
+func MakeTempDir(prefix string) (*TempDir, error) {
+	tmpDir, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		return nil, fmt.Errorf("temp.TempDir: couldn't ioutil.TempDir: %v", err)
 	}
 	return &TempDir{tmpDir}, err
 }

--- a/sched/scheduler/job_state.go
+++ b/sched/scheduler/job_state.go
@@ -84,6 +84,8 @@ func (j *jobState) taskCompleted(taskId string) {
 }
 
 // Update JobState to reflect that an error has occurred running this Task
+// Note: we are swallowing the error here (it has been printed to the log)
+// should we be doing this, or should we keep the latest error in the taskState?
 func (j *jobState) errorRunningTask(taskId string, err error) {
 	taskState := j.Tasks[taskId]
 	taskState.Status = sched.NotStarted

--- a/workerapi/client/client.go
+++ b/workerapi/client/client.go
@@ -4,8 +4,10 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/scootdev/scoot/common/dialer"
+	log "github.com/scootdev/scoot/common/logger"
 	"github.com/scootdev/scoot/runner"
 	"github.com/scootdev/scoot/runner/runners"
 	"github.com/scootdev/scoot/scootapi"
@@ -70,6 +72,7 @@ func (c *simpleClient) Close() error {
 
 // Implements Scoot Worker API
 func (c *simpleClient) Run(cmd *runner.Command) (runner.RunStatus, error) {
+	log.Tracef("Using worker:%s to run command:'%s'", c.addr, strings.Join(cmd.Argv, " "))
 	workerClient, err := c.dial()
 	if err != nil {
 		return runner.RunStatus{}, err


### PR DESCRIPTION
…s the initial implementation, it writes log files to scoot-tmp-log<xxx>/log.txt.  We can extend it with different loggers and externalize the ability to set the log level

would like initial review of the logging approach.  
- note the changes to task_runner.go (around line 54) were just to make the code more readable.

