### PR TITLE
Poll indefinitely if there is no timeout

### DIFF
--- a/runner/runners/polling.go
+++ b/runner/runners/polling.go
@@ -34,18 +34,14 @@ func (r *PollingStatusQuerier) QueryNow(q runner.Query) ([]runner.RunStatus, err
 // Query returns all RunStatus'es matching q, waiting as described by w
 func (r *PollingStatusQuerier) Query(q runner.Query, wait runner.Wait) ([]runner.RunStatus, error) {
 	end := time.Now().Add(wait.Timeout)
-	for {
-		switch time.Now().Before(end) || wait.Timeout == 0 {
-		case true:
-			st, err := r.QueryNow(q)
-			if err != nil || len(st) > 0 {
-				return st, err
-			}
-			time.Sleep(r.period)
-		default:
-			return nil, nil
+	for time.Now().Before(end) || wait.Timeout == 0 {
+		st, err := r.QueryNow(q)
+		if err != nil || len(st) > 0 {
+			return st, err
 		}
+		time.Sleep(r.period)
 	}
+	return nil, nil
 }
 
 // Status returns the current status of id from q.

--- a/runner/runners/polling.go
+++ b/runner/runners/polling.go
@@ -34,7 +34,13 @@ func (r *PollingStatusQuerier) QueryNow(q runner.Query) ([]runner.RunStatus, err
 // Query returns all RunStatus'es matching q, waiting as described by w
 func (r *PollingStatusQuerier) Query(q runner.Query, wait runner.Wait) ([]runner.RunStatus, error) {
 	if wait.Timeout == 0 {
-		return r.del.QueryNow(q)
+		for {
+			st, err := r.del.QueryNow(q)
+			if err != nil || len(st) > 0 {
+				return st, err
+			}
+			time.Sleep(r.period)
+		}
 	}
 	end := time.Now().Add(wait.Timeout)
 	for time.Now().Before(end) {

--- a/runner/runners/polling.go
+++ b/runner/runners/polling.go
@@ -35,13 +35,14 @@ func (r *PollingStatusQuerier) QueryNow(q runner.Query) ([]runner.RunStatus, err
 func (r *PollingStatusQuerier) Query(q runner.Query, wait runner.Wait) ([]runner.RunStatus, error) {
 	end := time.Now().Add(wait.Timeout)
 	for {
-		if time.Now().Before(end) || wait.Timeout == 0 {
+		switch time.Now().Before(end) || wait.Timeout == 0 {
+		case true:
 			st, err := r.QueryNow(q)
 			if err != nil || len(st) > 0 {
 				return st, err
 			}
 			time.Sleep(r.period)
-		} else {
+		default:
 			return nil, nil
 		}
 	}

--- a/runner/runners/polling_test.go
+++ b/runner/runners/polling_test.go
@@ -73,7 +73,7 @@ func TestPollingWorker_Wait(t *testing.T) {
 func TestPollingWorker_Timeout(t *testing.T) {
 	_, _, poller := setupPoller()
 	stCh, errCh := make(chan runner.RunStatus), make(chan error)
-	st, err := poller.Run(&runner.Command{Argv: []string{"sleep 1001"}, Timeout: time.Second * 1})
+	st, err := poller.Run(&runner.Command{Argv: []string{"sleep 1000"}, Timeout: time.Millisecond * 20})
 
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func TestPollingWorker_Timeout(t *testing.T) {
 	select {
 	case st := <-stCh:
 		err := <-errCh
-		t.Log("status and err:", st, err)
+		t.Log("should still be waiting:", st, err)
 	default:
 	}
 


### PR DESCRIPTION
Tasks have been timing out without a timeout being set. This is because the timeout default value is 0. A timeout of 0 should be read as absence of a timeout, not as a 0 second timeout. If there is no timeout, then we should poll indefinitely.