### PR TITLE
rcouto/log15

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,6 +57,10 @@
 	path = vendor/github.com/scootdev/groupcache
 	url = https://github.com/scootdev/groupcache
 	branch = 85fde1c5c36988481c30fc26605cd83f21cc94d1
+[submodule "vendor/github.com/scootdev/groupcache"]
+	path = vendor/github.com/inconshreveable/log15
+	url = https://github.com/inconshreveable/log15
+	branch = 39bacc234bf1afd0b68573e95b45871f67ba2cd4
 
 #
 # Everything after here is a transitive dependency that is not required to use scoot.

--- a/.gitmodules
+++ b/.gitmodules
@@ -203,3 +203,11 @@
 	path = vendor/github.com/pmezard/go-difflib
 	url = https://github.com/pmezard/go-difflib.git
 	branch = 792786c7400a136282c1664665ae0a8db921c6c2
+[submodule "vendor/github.com/go-stack/stack"]
+	path = vendor/github.com/go-stack/stack
+	url = https://github.com/go-stack/stack
+	branch = 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
+[submodule "vendor/github.com/mattn/go-colorable"]
+	path = vendor/github.com/mattn/go-colorable
+	url = https://github.com/mattn/go-colorable
+	branch = ded68f7a9561c023e790de24279db7ebf473ea80

--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	path = vendor/github.com/scootdev/groupcache
 	url = https://github.com/scootdev/groupcache
 	branch = 85fde1c5c36988481c30fc26605cd83f21cc94d1
-[submodule "vendor/github.com/scootdev/groupcache"]
+[submodule "vendor/github.com/inconshreveable/log15"]
 	path = vendor/github.com/inconshreveable/log15
 	url = https://github.com/inconshreveable/log15
 	branch = 39bacc234bf1afd0b68573e95b45871f67ba2cd4

--- a/binaries/apiserver/main.go
+++ b/binaries/apiserver/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"net/http"
 	"time"
 
@@ -25,7 +25,7 @@ func main() {
 	configFlag := flag.String("config", "{}", "API Server Config (either a filename like local.local or JSON text")
 	flag.Parse()
 
-	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+	// log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
 
 	// The same config will be used for both bundlestore and frontend (TODO: frontend).
 	asset := func(s string) ([]byte, error) {
@@ -33,7 +33,7 @@ func main() {
 	}
 	configText, err := jsonconfig.GetConfigText(*configFlag, asset)
 	if err != nil {
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 
 	type StoreAndHandler struct {

--- a/binaries/apiserver/main.go
+++ b/binaries/apiserver/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"net/http"
 	"time"
 

--- a/binaries/apiserver/main.go
+++ b/binaries/apiserver/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"net/http"
 	"time"
 

--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"time"
 
 	"github.com/scootdev/scoot/daemon/server"
@@ -27,33 +27,33 @@ func main() {
 	case "os":
 		ex = os_exec.NewExecer()
 	default:
-		log.Fatalf("Unknown execer type %v", *execerType)
+		log.Crit("Unknown execer type %v", *execerType)
 	}
 
 	tempDir, err := temp.TempDirDefault()
 	if err != nil {
-		log.Fatal("error creating temp dir: ", err)
+		log.Crit("error creating temp dir: ", err)
 	}
 	//defer os.RemoveAll(tempDir.Dir) //TODO: this may become necessary if we start testing with larger snapshots.
 
 	tmp, err := temp.NewTempDir("", "daemon")
 	if err != nil {
-		log.Fatal("Cannot create tmp dir: ", err)
+		log.Crit("Cannot create tmp dir: ", err)
 	}
 
 	outputCreator, err := runners.NewHttpOutputCreator(tempDir, "")
 	if err != nil {
-		log.Fatal("Cannot create OutputCreator: ", err)
+		log.Crit("Cannot create OutputCreator: ", err)
 	}
 	filer := snapshots.MakeTempFiler(tempDir)
 	r := runners.NewQueueRunner(ex, filer, outputCreator, tmp, *qLen)
 	h := server.NewHandler(r, filer, 50*time.Millisecond)
 	s, err := server.NewServer(h)
 	if err != nil {
-		log.Fatal("Cannot create Scoot server: ", err)
+		log.Crit("Cannot create Scoot server: ", err)
 	}
 	err = s.ListenAndServe()
 	if err != nil {
-		log.Fatal("Error serving Scoot Daemon: ", err)
+		log.Crit("Error serving Scoot Daemon: ", err)
 	}
 }

--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"time"
 
 	"github.com/scootdev/scoot/daemon/server"

--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"time"
 
 	"github.com/scootdev/scoot/daemon/server"

--- a/binaries/minfs/main.go
+++ b/binaries/minfs/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/scootdev/scoot/fs/minfuse"
 )

--- a/binaries/minfs/main.go
+++ b/binaries/minfs/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	minfuse.SetupLog()
 	if opts, err := minfuse.InitFlags(); err != nil {
-		log.Info(err.Error())
+		log.Debug(err.Error())
 		return
 	} else {
 		minfuse.Runfs(opts)

--- a/binaries/minfs/main.go
+++ b/binaries/minfs/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/scootdev/scoot/fs/minfuse"
 )
@@ -9,7 +9,7 @@ import (
 func main() {
 	minfuse.SetupLog()
 	if opts, err := minfuse.InitFlags(); err != nil {
-		log.Print(err)
+		log.Info(err.Error())
 		return
 	} else {
 		minfuse.Runfs(opts)

--- a/binaries/minfs/main.go
+++ b/binaries/minfs/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	minfuse.SetupLog()
 	if opts, err := minfuse.InitFlags(); err != nil {
-		log.Debug(err.Error())
+		log.Info(err.Error())
 		return
 	} else {
 		minfuse.Runfs(opts)

--- a/binaries/minfs/main.go
+++ b/binaries/minfs/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/scootdev/scoot/fs/minfuse"
 )

--- a/binaries/recoverytest/main.go
+++ b/binaries/recoverytest/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"sync"
 	"time"
 

--- a/binaries/recoverytest/main.go
+++ b/binaries/recoverytest/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"sync"
 	"time"
 

--- a/binaries/recoverytest/main.go
+++ b/binaries/recoverytest/main.go
@@ -28,7 +28,7 @@ func main() {
 	testhelpers.WaitForClusterToBeReady(scootClient)
 
 	// Add a Bunch of Jobs to Scoot CloudExec
-	log.Info("Add Jobs to Scoot Cloud Exec")
+	log.Debug("Add Jobs to Scoot Cloud Exec")
 	jobIds := make([]string, 0, numJobs)
 	for i := 0; i < numJobs; i++ {
 		jobIds = append(jobIds, testhelpers.StartJob(scootClient, testhelpers.GenerateJob(-1, "")))
@@ -47,7 +47,7 @@ func main() {
 	// Wait for Jobs to Start Running and make some progress
 	time.Sleep(1 * time.Second)
 
-	log.Info(
+	log.Debug(
 		`-------------------------------KILLING CLUSTER-------------------------------
                                      ________________
                             ____/ (  (    )   )  \___
@@ -75,7 +75,7 @@ func main() {
   -------------------------------------------------------------------------------`)
 	cluster1Cmds.Kill()
 
-	log.Info("Reviving Cluster")
+	log.Debug("Reviving Cluster")
 	cluster2Cmds, err := testhelpers.CreateLocalTestCluster()
 	if err != nil {
 		log.Crit("Unexpected Error while Setting up Recovery Cluster %v", err)
@@ -84,5 +84,5 @@ func main() {
 
 	// Wait for all jobs to complete
 	wg.Wait()
-	log.Info("All Jobs Completed Successfully")
+	log.Debug("All Jobs Completed Successfully")
 }

--- a/binaries/recoverytest/main.go
+++ b/binaries/recoverytest/main.go
@@ -28,7 +28,7 @@ func main() {
 	testhelpers.WaitForClusterToBeReady(scootClient)
 
 	// Add a Bunch of Jobs to Scoot CloudExec
-	log.Debug("Add Jobs to Scoot Cloud Exec")
+	log.Info("Add Jobs to Scoot Cloud Exec")
 	jobIds := make([]string, 0, numJobs)
 	for i := 0; i < numJobs; i++ {
 		jobIds = append(jobIds, testhelpers.StartJob(scootClient, testhelpers.GenerateJob(-1, "")))
@@ -47,7 +47,7 @@ func main() {
 	// Wait for Jobs to Start Running and make some progress
 	time.Sleep(1 * time.Second)
 
-	log.Debug(
+	log.Info(
 		`-------------------------------KILLING CLUSTER-------------------------------
                                      ________________
                             ____/ (  (    )   )  \___
@@ -75,7 +75,7 @@ func main() {
   -------------------------------------------------------------------------------`)
 	cluster1Cmds.Kill()
 
-	log.Debug("Reviving Cluster")
+	log.Info("Reviving Cluster")
 	cluster2Cmds, err := testhelpers.CreateLocalTestCluster()
 	if err != nil {
 		log.Crit("Unexpected Error while Setting up Recovery Cluster %v", err)
@@ -84,5 +84,5 @@ func main() {
 
 	// Wait for all jobs to complete
 	wg.Wait()
-	log.Debug("All Jobs Completed Successfully")
+	log.Info("All Jobs Completed Successfully")
 }

--- a/binaries/recoverytest/main.go
+++ b/binaries/recoverytest/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"sync"
 	"time"
 
@@ -21,14 +21,14 @@ func main() {
 	// Initialize Local Cluster
 	cluster1Cmds, err := testhelpers.CreateLocalTestCluster()
 	if err != nil {
-		log.Fatalf("Unexpected Error while Setting up Local Cluster %v", err)
+		log.Crit("Unexpected Error while Setting up Local Cluster %v", err)
 	}
 	defer cluster1Cmds.Kill()
 
 	testhelpers.WaitForClusterToBeReady(scootClient)
 
 	// Add a Bunch of Jobs to Scoot CloudExec
-	log.Printf("Add Jobs to Scoot Cloud Exec")
+	log.Info("Add Jobs to Scoot Cloud Exec")
 	jobIds := make([]string, 0, numJobs)
 	for i := 0; i < numJobs; i++ {
 		jobIds = append(jobIds, testhelpers.StartJob(scootClient, testhelpers.GenerateJob(-1, "")))
@@ -40,14 +40,14 @@ func main() {
 		defer wg.Done()
 		err := testhelpers.WaitForJobsToCompleteAndLogStatus(jobIds, scootClient, timeout)
 		if err != nil {
-			log.Fatalf("Error Occurred Waiting For Jobs to Complete.  %v", err)
+			log.Crit("Error Occurred Waiting For Jobs to Complete.  %v", err)
 		}
 	}()
 
 	// Wait for Jobs to Start Running and make some progress
 	time.Sleep(1 * time.Second)
 
-	log.Printf(
+	log.Info(
 		`-------------------------------KILLING CLUSTER-------------------------------
                                      ________________
                             ____/ (  (    )   )  \___
@@ -75,14 +75,14 @@ func main() {
   -------------------------------------------------------------------------------`)
 	cluster1Cmds.Kill()
 
-	log.Printf("Reviving Cluster")
+	log.Info("Reviving Cluster")
 	cluster2Cmds, err := testhelpers.CreateLocalTestCluster()
 	if err != nil {
-		log.Fatalf("Unexpected Error while Setting up Recovery Cluster %v", err)
+		log.Crit("Unexpected Error while Setting up Recovery Cluster %v", err)
 	}
 	defer cluster2Cmds.Kill()
 
 	// Wait for all jobs to complete
 	wg.Wait()
-	log.Printf("All Jobs Completed Successfully")
+	log.Info("All Jobs Completed Successfully")
 }

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -45,6 +45,6 @@ func main() {
 		},
 	)
 
-	log.Debug("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
+	log.Info("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/apache/thrift/lib/go/thrift"
 

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/apache/thrift/lib/go/thrift"
 
@@ -26,11 +26,11 @@ var configFlag = flag.String("config", "local.memory", "Scheduler Config (either
 func main() {
 	flag.Parse()
 
-	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+	// log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
 
 	configText, err := jsonconfig.GetConfigText(*configFlag, config.Asset)
 	if err != nil {
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 	bag, schema := server.Defaults()
 	bag.PutMany(
@@ -45,6 +45,6 @@ func main() {
 		},
 	)
 
-	log.Println("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
+	log.Info("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/scheduler/main.go
+++ b/binaries/scheduler/main.go
@@ -45,6 +45,6 @@ func main() {
 		},
 	)
 
-	log.Info("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
+	log.Debug("Starting Cloud Scoot API Server & Scheduler on", *thriftAddr)
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/scoot-snapshot-db/main.go
+++ b/binaries/scoot-snapshot-db/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 
 	"github.com/spf13/cobra"

--- a/binaries/scoot-snapshot-db/main.go
+++ b/binaries/scoot-snapshot-db/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 
 	"github.com/spf13/cobra"

--- a/binaries/scoot-snapshot-db/main.go
+++ b/binaries/scoot-snapshot-db/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,12 +18,12 @@ import (
 )
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+	// log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
 
 	inj := &injector{}
 	cmd := cli.MakeDBCLI(inj)
 	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 }
 

--- a/binaries/scootapi/main.go
+++ b/binaries/scootapi/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/dialer"
@@ -18,7 +18,7 @@ import (
 //		--addr [<host:port> of cloud server]
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+	// log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
 
 	transportFactory := thrift.NewTTransportFactory()
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
@@ -26,11 +26,11 @@ func main() {
 	di := dialer.NewSimpleDialer(transportFactory, protocolFactory)
 	cl, err := client.NewSimpleCLIClient(di)
 	if err != nil {
-		log.Fatal("Failed to create new ScootAPI CLI client: ", err)
+		log.Crit("Failed to create new ScootAPI CLI client: ", err)
 	}
 
 	err = cl.Exec()
 	if err != nil {
-		log.Fatal("Error running scootapi ", err)
+		log.Crit("Error running scootapi ", err)
 	}
 }

--- a/binaries/scootapi/main.go
+++ b/binaries/scootapi/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/dialer"

--- a/binaries/scootapi/main.go
+++ b/binaries/scootapi/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/dialer"

--- a/binaries/setup-cloud-scoot/main.go
+++ b/binaries/setup-cloud-scoot/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi/setup"

--- a/binaries/setup-cloud-scoot/main.go
+++ b/binaries/setup-cloud-scoot/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi/setup"

--- a/binaries/setup-cloud-scoot/main.go
+++ b/binaries/setup-cloud-scoot/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi/setup"
@@ -17,11 +17,11 @@ func main() {
 	apiserversFlag := flag.Int("apiservers", setup.DefaultApiServerCount, "number of apiservers to use")
 	flag.Parse()
 
-	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+	// log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
 
 	tmp, err := temp.NewTempDir("", "setup-cloud-scoot-")
 	if err != nil {
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 
 	cmds := setup.NewSignalHandlingCmds(tmp)
@@ -43,6 +43,6 @@ func main() {
 	strategies := &setup.Strategies{Sched: sched, SchedStrategy: *schedStrategy, Api: api, ApiStrategy: *apiStrategy}
 	if err := setup.Main(cmds, strategies, flag.Args()); err != nil {
 		cmds.Kill()
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 }

--- a/binaries/workercl/main.go
+++ b/binaries/workercl/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/dialer"
@@ -23,11 +23,11 @@ func main() {
 	di := dialer.NewSimpleDialer(transportFactory, protocolFactory)
 	cl, err := client.NewSimpleCLIClient(di)
 	if err != nil {
-		log.Fatal("Failed to create worker CLIClient: ", err)
+		log.Crit("Failed to create worker CLIClient: ", err)
 	}
 
 	err = cl.Exec()
 	if err != nil {
-		log.Fatal("Error running workercl: ", err)
+		log.Crit("Error running workercl: ", err)
 	}
 }

--- a/binaries/workercl/main.go
+++ b/binaries/workercl/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/dialer"

--- a/binaries/workercl/main.go
+++ b/binaries/workercl/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/dialer"

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -90,19 +90,19 @@ func main() {
 			if len(nodes) > 0 {
 				r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 				storeAddr = string(nodes[r.Intn(len(nodes))].Id())
-				log.Info("No stores specified, but successfully fetched store addr: ", nodes, " --> ", storeAddr)
+				log.Debug("No stores specified, but successfully fetched store addr: ", nodes, " --> ", storeAddr)
 			} else {
 				_, storeAddr, _ = scootapi.GetScootapiAddr()
-				log.Info("No stores specified, but successfully read .cloudscootaddr: ", storeAddr)
+				log.Debug("No stores specified, but successfully read .cloudscootaddr: ", storeAddr)
 			}
 			if storeAddr != "" {
 				return bundlestore.MakeHTTPStore(scootapi.APIAddrToBundlestoreURI(storeAddr)), nil
 			}
-			log.Info("No stores specified or found, creating a tmp file store")
+			log.Debug("No stores specified or found, creating a tmp file store")
 			return bundlestore.MakeFileStoreInTemp(tmp)
 		},
 	)
 
-	log.Info("Serving thrift on", *thriftAddr) //It's hard to access the thriftAddr value downstream, print it here.
+	log.Debug("Serving thrift on", *thriftAddr) //It's hard to access the thriftAddr value downstream, print it here.
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -90,19 +90,19 @@ func main() {
 			if len(nodes) > 0 {
 				r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 				storeAddr = string(nodes[r.Intn(len(nodes))].Id())
-				log.Debug("No stores specified, but successfully fetched store addr: ", nodes, " --> ", storeAddr)
+				log.Info("No stores specified, but successfully fetched store addr: ", nodes, " --> ", storeAddr)
 			} else {
 				_, storeAddr, _ = scootapi.GetScootapiAddr()
-				log.Debug("No stores specified, but successfully read .cloudscootaddr: ", storeAddr)
+				log.Info("No stores specified, but successfully read .cloudscootaddr: ", storeAddr)
 			}
 			if storeAddr != "" {
 				return bundlestore.MakeHTTPStore(scootapi.APIAddrToBundlestoreURI(storeAddr)), nil
 			}
-			log.Debug("No stores specified or found, creating a tmp file store")
+			log.Info("No stores specified or found, creating a tmp file store")
 			return bundlestore.MakeFileStoreInTemp(tmp)
 		},
 	)
 
-	log.Debug("Serving thrift on", *thriftAddr) //It's hard to access the thriftAddr value downstream, print it here.
+	log.Info("Serving thrift on", *thriftAddr) //It's hard to access the thriftAddr value downstream, print it here.
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"math/rand"
 	"net/http"
 	"strings"

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"flag"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -38,11 +38,11 @@ var storeHandle = flag.String("bundlestore", "", "Abs file path or an http 'host
 func main() {
 	flag.Parse()
 
-	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+	// log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
 
 	configText, err := jsonconfig.GetConfigText(*configFlag, config.Asset)
 	if err != nil {
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 
 	bag := ice.NewMagicBag()
@@ -90,19 +90,19 @@ func main() {
 			if len(nodes) > 0 {
 				r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 				storeAddr = string(nodes[r.Intn(len(nodes))].Id())
-				log.Print("No stores specified, but successfully fetched store addr: ", nodes, " --> ", storeAddr)
+				log.Info("No stores specified, but successfully fetched store addr: ", nodes, " --> ", storeAddr)
 			} else {
 				_, storeAddr, _ = scootapi.GetScootapiAddr()
-				log.Print("No stores specified, but successfully read .cloudscootaddr: ", storeAddr)
+				log.Info("No stores specified, but successfully read .cloudscootaddr: ", storeAddr)
 			}
 			if storeAddr != "" {
 				return bundlestore.MakeHTTPStore(scootapi.APIAddrToBundlestoreURI(storeAddr)), nil
 			}
-			log.Print("No stores specified or found, creating a tmp file store")
+			log.Info("No stores specified or found, creating a tmp file store")
 			return bundlestore.MakeFileStoreInTemp(tmp)
 		},
 	)
 
-	log.Println("Serving thrift on", *thriftAddr) //It's hard to access the thriftAddr value downstream, print it here.
+	log.Info("Serving thrift on", *thriftAddr) //It's hard to access the thriftAddr value downstream, print it here.
 	server.RunServer(bag, schema, configText)
 }

--- a/binaries/workerserver/main.go
+++ b/binaries/workerserver/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"flag"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"math/rand"
 	"net/http"
 	"strings"

--- a/common/dialer/dialer.go
+++ b/common/dialer/dialer.go
@@ -4,7 +4,7 @@ package dialer
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )

--- a/common/dialer/dialer.go
+++ b/common/dialer/dialer.go
@@ -26,7 +26,7 @@ func NewSimpleDialer(tf thrift.TTransportFactory, pf thrift.TProtocolFactory) Di
 }
 
 func (d *simpleDialer) Dial(addr string) (thrift.TTransport, thrift.TProtocolFactory, error) {
-	log.Debug("Dialing", addr)
+	log.Info("Dialing", addr)
 
 	var transport thrift.TTransport
 	transport, err := thrift.NewTSocket(addr)

--- a/common/dialer/dialer.go
+++ b/common/dialer/dialer.go
@@ -4,7 +4,7 @@ package dialer
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )

--- a/common/dialer/dialer.go
+++ b/common/dialer/dialer.go
@@ -26,7 +26,7 @@ func NewSimpleDialer(tf thrift.TTransportFactory, pf thrift.TProtocolFactory) Di
 }
 
 func (d *simpleDialer) Dial(addr string) (thrift.TTransport, thrift.TProtocolFactory, error) {
-	log.Info("Dialing", addr)
+	log.Debug("Dialing", addr)
 
 	var transport thrift.TTransport
 	transport, err := thrift.NewTSocket(addr)

--- a/common/dialer/dialer.go
+++ b/common/dialer/dialer.go
@@ -4,7 +4,7 @@ package dialer
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )
@@ -26,7 +26,7 @@ func NewSimpleDialer(tf thrift.TTransportFactory, pf thrift.TProtocolFactory) Di
 }
 
 func (d *simpleDialer) Dial(addr string) (thrift.TTransport, thrift.TProtocolFactory, error) {
-	log.Println("Dialing", addr)
+	log.Info("Dialing", addr)
 
 	var transport thrift.TTransport
 	transport, err := thrift.NewTSocket(addr)

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -5,8 +5,8 @@ package endpoints
 import (
 	"bytes"
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"net/http"
 	"time"
 
@@ -41,7 +41,7 @@ func (s *TwitterServer) Serve() error {
 	for path, handler := range s.Handlers {
 		mux.Handle(path, handler)
 	}
-	log.Println("Serving http & stats on", s.Addr)
+	log.Info("Serving http & stats on", s.Addr)
 	server := &http.Server{
 		Addr:    s.Addr,
 		Handler: mux,

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -5,7 +5,7 @@ package endpoints
 import (
 	"bytes"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"net/http"
 	"time"

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -41,7 +41,7 @@ func (s *TwitterServer) Serve() error {
 	for path, handler := range s.Handlers {
 		mux.Handle(path, handler)
 	}
-	log.Debug("Serving http & stats on", s.Addr)
+	log.Info("Serving http & stats on", s.Addr)
 	server := &http.Server{
 		Addr:    s.Addr,
 		Handler: mux,

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -41,7 +41,7 @@ func (s *TwitterServer) Serve() error {
 	for path, handler := range s.Handlers {
 		mux.Handle(path, handler)
 	}
-	log.Info("Serving http & stats on", s.Addr)
+	log.Debug("Serving http & stats on", s.Addr)
 	server := &http.Server{
 		Addr:    s.Addr,
 		Handler: mux,

--- a/common/endpoints/endpoints.go
+++ b/common/endpoints/endpoints.go
@@ -5,7 +5,7 @@ package endpoints
 import (
 	"bytes"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"net/http"
 	"time"

--- a/common/endpoints/setup.go
+++ b/common/endpoints/setup.go
@@ -36,7 +36,7 @@ func (m module) Install(b *ice.MagicBag) {
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	// Parse Config
-	log.Info("common/endpoints RunServer(), config is:", string(config))
+	log.Debug("common/endpoints RunServer(), config is:", string(config))
 	mod, err := schema.Parse(config)
 	if err != nil {
 		log.Crit("Error configuring Scoot API: ", err)

--- a/common/endpoints/setup.go
+++ b/common/endpoints/setup.go
@@ -36,7 +36,7 @@ func (m module) Install(b *ice.MagicBag) {
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	// Parse Config
-	log.Debug("common/endpoints RunServer(), config is:", string(config))
+	log.Info("common/endpoints RunServer(), config is:", string(config))
 	mod, err := schema.Parse(config)
 	if err != nil {
 		log.Crit("Error configuring Scoot API: ", err)

--- a/common/endpoints/setup.go
+++ b/common/endpoints/setup.go
@@ -1,7 +1,7 @@
 package endpoints
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"net/http"
 	"time"
 
@@ -36,10 +36,10 @@ func (m module) Install(b *ice.MagicBag) {
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	// Parse Config
-	log.Println("common/endpoints RunServer(), config is:", string(config))
+	log.Info("common/endpoints RunServer(), config is:", string(config))
 	mod, err := schema.Parse(config)
 	if err != nil {
-		log.Fatal("Error configuring Scoot API: ", err)
+		log.Crit("Error configuring Scoot API: ", err)
 	}
 
 	// Initialize Objects Based on Config Settings
@@ -49,8 +49,9 @@ func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	var server *TwitterServer
 	err = bag.Extract(&server)
 	if err != nil {
-		log.Fatal("Error injecting server", err)
+		log.Crit("Error injecting server", err)
 	}
-
-	log.Fatal(server.Serve())
+	if err = server.Serve(); err != nil {
+		log.Crit(err.Error())
+	}
 }

--- a/common/endpoints/setup.go
+++ b/common/endpoints/setup.go
@@ -1,7 +1,7 @@
 package endpoints
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"net/http"
 	"time"
 

--- a/common/endpoints/setup.go
+++ b/common/endpoints/setup.go
@@ -1,7 +1,7 @@
 package endpoints
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"net/http"
 	"time"
 

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -6,14 +6,14 @@
 // Ex. For logging file & line # to stdout,
 //
 // import (
-// 		log "github.com/scootdev/scoot/common/logger"
+// 		"github.com/scootdev/scoot/common/log"
 // 		"github.com/inconshreveable/log15"
 // )
 //
 // h := log15.CallerFileHandler(log15.StdoutHandler)
 // log.SetHandler(h)
 
-package logger
+package log
 
 import log "github.com/inconshreveable/log15"
 

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -21,7 +21,7 @@ var Log = log.New()
 
 // New returns a new Logger that has this logger's context plus the given context
 func New(ctx ...interface{}) log.Logger {
-	return log.New(ctx)
+	return Log.New(ctx)
 }
 
 // GetHandler gets the handler associated with the logger.

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -1,19 +1,46 @@
 // Wrapper for github.com/inconshreveable/log15
-// Allows configurable handlers for users of scoot
+// Allows configurable handlers for users of Scoot logging
 // log15 handler docs are available at:
 // https://godoc.org/github.com/inconshreveable/log15#Handler
+//
+// Ex. For logging file & line # to stdout,
+//
+// import (
+// 		log "github.com/scootdev/scoot/common/logger"
+// 		"github.com/inconshreveable/log15"
+// )
+//
+// h := log15.CallerFileHandler(log15.StdoutHandler)
+// log.SetHandler(h)
+
 package logger
 
 import log "github.com/inconshreveable/log15"
 
 var Log = log.New()
 
-func Info(msg string, ctx ...interface{}) {
-	Log.Info(msg, ctx)
+// New returns a new Logger that has this logger's context plus the given context
+func New(ctx ...interface{}) log.Logger {
+	return log.New(ctx)
 }
 
+// GetHandler gets the handler associated with the logger.
+func GetHandler() log.Handler {
+	return Log.GetHandler()
+}
+
+// SetHandler updates the logger to write records to the specified handler.
+func SetHandler(h log.Handler) {
+	Log.SetHandler(h)
+}
+
+// Log a message at the given level with context key/value pairs
 func Debug(msg string, ctx ...interface{}) {
 	Log.Debug(msg, ctx)
+}
+
+func Info(msg string, ctx ...interface{}) {
+	Log.Info(msg, ctx)
 }
 
 func Crit(msg string, ctx ...interface{}) {

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -1,0 +1,22 @@
+// Wrapper for github.com/inconshreveable/log15
+// Allows configurable handlers for usage within Twitter source
+// Levels available for use are (in ascending order)
+// Crit, Info, and Debug
+
+package logger
+
+import log "github.com/inconshreveable/log15"
+
+var Log = log.New()
+
+func Info(msg string, ctx ...interface{}) {
+	Log.Info(msg, ctx)
+}
+
+func Debug(msg string, ctx ...interface{}) {
+	Log.Debug(msg, ctx)
+}
+
+func Crit(msg string, ctx ...interface{}) {
+	Log.Crit(msg, ctx)
+}

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -1,8 +1,7 @@
 // Wrapper for github.com/inconshreveable/log15
-// Allows configurable handlers for usage within Twitter source
-// Levels available for use are (in ascending order)
-// Crit, Info, and Debug
-
+// Allows configurable handlers for users of scoot
+// log15 handler docs are available at:
+// https://godoc.org/github.com/inconshreveable/log15#Handler
 package logger
 
 import log "github.com/inconshreveable/log15"

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -199,7 +199,7 @@ func capture(src StatsRegistry, captured StatsRegistry) StatsRegistry {
 		case Latency:
 			captured.GetOrRegister(name, m.Capture())
 		default:
-			log.Debug("Unrecognized capture instrument: ", name, i)
+			log.Info("Unrecognized capture instrument: ", name, i)
 		}
 	})
 	return captured
@@ -480,7 +480,7 @@ func (r *finagleStatsRegistry) MarshalAll() jsonMap {
 			l := stat.Capture()
 			r.marshalHistogram(data, name, l.(HistogramView), l.GetPrecision())
 		default:
-			log.Debug("Unrecognized marshal instrument: ", name, i)
+			log.Info("Unrecognized marshal instrument: ", name, i)
 		}
 	})
 	return data

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -18,7 +18,7 @@ package stats
 
 import (
 	"encoding/json"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"strings"
 	"time"
 

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -199,7 +199,7 @@ func capture(src StatsRegistry, captured StatsRegistry) StatsRegistry {
 		case Latency:
 			captured.GetOrRegister(name, m.Capture())
 		default:
-			log.Info("Unrecognized capture instrument: ", name, i)
+			log.Debug("Unrecognized capture instrument: ", name, i)
 		}
 	})
 	return captured
@@ -480,7 +480,7 @@ func (r *finagleStatsRegistry) MarshalAll() jsonMap {
 			l := stat.Capture()
 			r.marshalHistogram(data, name, l.(HistogramView), l.GetPrecision())
 		default:
-			log.Info("Unrecognized marshal instrument: ", name, i)
+			log.Debug("Unrecognized marshal instrument: ", name, i)
 		}
 	})
 	return data

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -18,7 +18,7 @@ package stats
 
 import (
 	"encoding/json"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"strings"
 	"time"
 
@@ -199,7 +199,7 @@ func capture(src StatsRegistry, captured StatsRegistry) StatsRegistry {
 		case Latency:
 			captured.GetOrRegister(name, m.Capture())
 		default:
-			log.Println("Unrecognized capture instrument: ", name, i)
+			log.Info("Unrecognized capture instrument: ", name, i)
 		}
 	})
 	return captured
@@ -480,7 +480,7 @@ func (r *finagleStatsRegistry) MarshalAll() jsonMap {
 			l := stat.Capture()
 			r.marshalHistogram(data, name, l.(HistogramView), l.GetPrecision())
 		default:
-			log.Println("Unrecognized marshal instrument: ", name, i)
+			log.Info("Unrecognized marshal instrument: ", name, i)
 		}
 	})
 	return data

--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -18,7 +18,7 @@ package stats
 
 import (
 	"encoding/json"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"strings"
 	"time"
 

--- a/config/jsonconfig/config.go
+++ b/config/jsonconfig/config.go
@@ -3,7 +3,7 @@ package jsonconfig
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"path"
 	"regexp"
 
@@ -55,7 +55,7 @@ func (schema Schema) Parse(text []byte) (Configuration, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't parse top-level config: %v", err)
 	}
-	log.Printf("config parsed to:%+v\n", parsedConfig)
+	log.Info("config parsed to:%+v\n", parsedConfig)
 
 	result := Configuration(make(map[string]ice.Module))
 	// Parse each option (aka Implementations, which isn't a valid variable name)
@@ -102,13 +102,13 @@ func parseType(data json.RawMessage) (string, error) {
 func GetConfigText(configFlag string, asset func(string) ([]byte, error)) ([]byte, error) {
 	if matched, _ := regexp.Match(`^[[:alnum:]]*\.[[:alnum:]]*$`, []byte(configFlag)); matched {
 		configFileName := path.Join("config", configFlag)
-		log.Printf("reading config filename %v", configFileName)
+		log.Info("reading config filename %v", configFileName)
 		configText, err := asset(configFileName)
 		if err != nil {
 			return nil, fmt.Errorf("Scheduler: Error Loading Config File %v: %v", configFileName, err)
 		}
 		return configText, nil
 	}
-	log.Printf("Scheduler: using -config as JSON config: %v", configFlag)
+	log.Info("Scheduler: using -config as JSON config: %v", configFlag)
 	return []byte(configFlag), nil
 }

--- a/config/jsonconfig/config.go
+++ b/config/jsonconfig/config.go
@@ -3,7 +3,7 @@ package jsonconfig
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"path"
 	"regexp"
 

--- a/config/jsonconfig/config.go
+++ b/config/jsonconfig/config.go
@@ -3,7 +3,7 @@ package jsonconfig
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"path"
 	"regexp"
 

--- a/config/jsonconfig/config.go
+++ b/config/jsonconfig/config.go
@@ -55,7 +55,7 @@ func (schema Schema) Parse(text []byte) (Configuration, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't parse top-level config: %v", err)
 	}
-	log.Debug("config parsed to:%+v\n", parsedConfig)
+	log.Info("config parsed to:%+v\n", parsedConfig)
 
 	result := Configuration(make(map[string]ice.Module))
 	// Parse each option (aka Implementations, which isn't a valid variable name)
@@ -102,13 +102,13 @@ func parseType(data json.RawMessage) (string, error) {
 func GetConfigText(configFlag string, asset func(string) ([]byte, error)) ([]byte, error) {
 	if matched, _ := regexp.Match(`^[[:alnum:]]*\.[[:alnum:]]*$`, []byte(configFlag)); matched {
 		configFileName := path.Join("config", configFlag)
-		log.Debug("reading config filename %v", configFileName)
+		log.Info("reading config filename %v", configFileName)
 		configText, err := asset(configFileName)
 		if err != nil {
 			return nil, fmt.Errorf("Scheduler: Error Loading Config File %v: %v", configFileName, err)
 		}
 		return configText, nil
 	}
-	log.Debug("Scheduler: using -config as JSON config: %v", configFlag)
+	log.Info("Scheduler: using -config as JSON config: %v", configFlag)
 	return []byte(configFlag), nil
 }

--- a/config/jsonconfig/config.go
+++ b/config/jsonconfig/config.go
@@ -55,7 +55,7 @@ func (schema Schema) Parse(text []byte) (Configuration, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't parse top-level config: %v", err)
 	}
-	log.Info("config parsed to:%+v\n", parsedConfig)
+	log.Debug("config parsed to:%+v\n", parsedConfig)
 
 	result := Configuration(make(map[string]ice.Module))
 	// Parse each option (aka Implementations, which isn't a valid variable name)
@@ -102,13 +102,13 @@ func parseType(data json.RawMessage) (string, error) {
 func GetConfigText(configFlag string, asset func(string) ([]byte, error)) ([]byte, error) {
 	if matched, _ := regexp.Match(`^[[:alnum:]]*\.[[:alnum:]]*$`, []byte(configFlag)); matched {
 		configFileName := path.Join("config", configFlag)
-		log.Info("reading config filename %v", configFileName)
+		log.Debug("reading config filename %v", configFileName)
 		configText, err := asset(configFileName)
 		if err != nil {
 			return nil, fmt.Errorf("Scheduler: Error Loading Config File %v: %v", configFileName, err)
 		}
 		return configText, nil
 	}
-	log.Info("Scheduler: using -config as JSON config: %v", configFlag)
+	log.Debug("Scheduler: using -config as JSON config: %v", configFlag)
 	return []byte(configFlag), nil
 }

--- a/fs/min/serve.go
+++ b/fs/min/serve.go
@@ -32,7 +32,7 @@ func Serve(conn *fuse.Conn, rootFs fs.FS, threadUnsafe bool) (done chan error) {
 }
 
 func serve(conn *fuse.Conn, serv *servlet, done chan error) {
-	log.Info("Serving ScootFS")
+	log.Debug("Serving ScootFS")
 	var scope *fuse.RequestScope
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -41,18 +41,18 @@ func serve(conn *fuse.Conn, serv *servlet, done chan error) {
 			n := runtime.Stack(buf, false)
 			buf = buf[:n]
 			if scope != nil {
-				log.Info("Panic recovered in handler: %v %v %v", rec, string(buf), scope.Req)
+				log.Debug("Panic recovered in handler: %v %v %v", rec, string(buf), scope.Req)
 				scope.Resp.RespondError(fmt.Errorf("%v", rec), scope)
 				scope.Release()
 			} else {
-				log.Info("Panic recovered in handler: %v %v", rec, string(buf))
+				log.Debug("Panic recovered in handler: %v %v", rec, string(buf))
 			}
 			conn.Close()
 			panic(rec)
 		}
 	}()
 	defer func() {
-		log.Info("Signaling done")
+		log.Debug("Signaling done")
 		done <- nil
 	}()
 
@@ -61,7 +61,7 @@ func serve(conn *fuse.Conn, serv *servlet, done chan error) {
 	for {
 		scope, err = conn.Read(alloc, serv)
 		if err != nil {
-			log.Info("Error reading request; quitting: %v", err)
+			log.Debug("Error reading request; quitting: %v", err)
 			done <- err
 			conn.Close()
 			return
@@ -181,7 +181,7 @@ func (s *servlet) HandleReaddir(req *fuse.ReaddirRequest, resp *fuse.ReaddirResp
 		var childrenInodes []fuse.NodeID
 		childrenInodes, err = s.controller.ReserveChildren(req.NodeID(), names)
 		if err != nil {
-			log.Info(err.Error())
+			log.Debug(err.Error())
 			return err
 		}
 

--- a/fs/min/serve.go
+++ b/fs/min/serve.go
@@ -2,7 +2,7 @@ package min
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"runtime"
 	"time"
 

--- a/fs/min/serve.go
+++ b/fs/min/serve.go
@@ -32,7 +32,7 @@ func Serve(conn *fuse.Conn, rootFs fs.FS, threadUnsafe bool) (done chan error) {
 }
 
 func serve(conn *fuse.Conn, serv *servlet, done chan error) {
-	log.Debug("Serving ScootFS")
+	log.Info("Serving ScootFS")
 	var scope *fuse.RequestScope
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -41,18 +41,18 @@ func serve(conn *fuse.Conn, serv *servlet, done chan error) {
 			n := runtime.Stack(buf, false)
 			buf = buf[:n]
 			if scope != nil {
-				log.Debug("Panic recovered in handler: %v %v %v", rec, string(buf), scope.Req)
+				log.Info("Panic recovered in handler: %v %v %v", rec, string(buf), scope.Req)
 				scope.Resp.RespondError(fmt.Errorf("%v", rec), scope)
 				scope.Release()
 			} else {
-				log.Debug("Panic recovered in handler: %v %v", rec, string(buf))
+				log.Info("Panic recovered in handler: %v %v", rec, string(buf))
 			}
 			conn.Close()
 			panic(rec)
 		}
 	}()
 	defer func() {
-		log.Debug("Signaling done")
+		log.Info("Signaling done")
 		done <- nil
 	}()
 
@@ -61,7 +61,7 @@ func serve(conn *fuse.Conn, serv *servlet, done chan error) {
 	for {
 		scope, err = conn.Read(alloc, serv)
 		if err != nil {
-			log.Debug("Error reading request; quitting: %v", err)
+			log.Info("Error reading request; quitting: %v", err)
 			done <- err
 			conn.Close()
 			return
@@ -181,7 +181,7 @@ func (s *servlet) HandleReaddir(req *fuse.ReaddirRequest, resp *fuse.ReaddirResp
 		var childrenInodes []fuse.NodeID
 		childrenInodes, err = s.controller.ReserveChildren(req.NodeID(), names)
 		if err != nil {
-			log.Debug(err.Error())
+			log.Info(err.Error())
 			return err
 		}
 

--- a/fs/min/serve.go
+++ b/fs/min/serve.go
@@ -2,7 +2,7 @@ package min
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"runtime"
 	"time"
 

--- a/fs/minfuse/fs.go
+++ b/fs/minfuse/fs.go
@@ -55,8 +55,8 @@ func (n *minNode) Readlink() (string, error) {
 
 func (n *minNode) Lookup(name string) (fs.Node, error) {
 	if Trace {
-		log.Debug("Min: Lookup entry ", n.p, name)
-		defer log.Debug("Min: Lookup exit ", n.p, name)
+		log.Info("Min: Lookup entry ", n.p, name)
+		defer log.Info("Min: Lookup exit ", n.p, name)
 	}
 
 	// minNode stores the joined path so pass discards=false.
@@ -77,8 +77,8 @@ func (n *minNode) Lookup(name string) (fs.Node, error) {
 
 func (n *minNode) Open() (fs.Handle, error) {
 	if Trace {
-		log.Debug("Min: Open entry ", n.p)
-		defer log.Debug("Min: Open exit ", n.p)
+		log.Info("Min: Open entry ", n.p)
+		defer log.Info("Min: Open exit ", n.p)
 	}
 	return &minHandle{n.fs, n.p}, nil
 }
@@ -94,8 +94,8 @@ func (h *minHandle) Release() error {
 
 func (h *minHandle) ReadAt(data []byte, offset int64) (int, error) {
 	if Trace {
-		log.Debug("Min: Read entry ", h.p)
-		defer log.Debug("Min: Read exit ", h.p)
+		log.Info("Min: Read entry ", h.p)
+		defer log.Info("Min: Read exit ", h.p)
 	}
 	//TODO: snap.Open() should be called from minNode.Open() instead.
 	f, err := h.fs.snap.Open(h.p)
@@ -109,8 +109,8 @@ func (h *minHandle) ReadAt(data []byte, offset int64) (int, error) {
 
 func (h *minHandle) ReadDirAll() ([]fuse.Dirent, error) {
 	if Trace {
-		log.Debug("Min: ReadDirAll entry ", h.p)
-		defer log.Debug("Min: ReadDirAll exit ", h.p)
+		log.Info("Min: ReadDirAll entry ", h.p)
+		defer log.Info("Min: ReadDirAll exit ", h.p)
 	}
 	dirents, err := h.fs.snap.Readdirents(h.p)
 	if err != nil {

--- a/fs/minfuse/fs.go
+++ b/fs/minfuse/fs.go
@@ -1,7 +1,7 @@
 package minfuse
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"os"
 	"syscall"

--- a/fs/minfuse/fs.go
+++ b/fs/minfuse/fs.go
@@ -55,8 +55,8 @@ func (n *minNode) Readlink() (string, error) {
 
 func (n *minNode) Lookup(name string) (fs.Node, error) {
 	if Trace {
-		log.Info("Min: Lookup entry ", n.p, name)
-		defer log.Info("Min: Lookup exit ", n.p, name)
+		log.Debug("Min: Lookup entry ", n.p, name)
+		defer log.Debug("Min: Lookup exit ", n.p, name)
 	}
 
 	// minNode stores the joined path so pass discards=false.
@@ -77,8 +77,8 @@ func (n *minNode) Lookup(name string) (fs.Node, error) {
 
 func (n *minNode) Open() (fs.Handle, error) {
 	if Trace {
-		log.Info("Min: Open entry ", n.p)
-		defer log.Info("Min: Open exit ", n.p)
+		log.Debug("Min: Open entry ", n.p)
+		defer log.Debug("Min: Open exit ", n.p)
 	}
 	return &minHandle{n.fs, n.p}, nil
 }
@@ -94,8 +94,8 @@ func (h *minHandle) Release() error {
 
 func (h *minHandle) ReadAt(data []byte, offset int64) (int, error) {
 	if Trace {
-		log.Info("Min: Read entry ", h.p)
-		defer log.Info("Min: Read exit ", h.p)
+		log.Debug("Min: Read entry ", h.p)
+		defer log.Debug("Min: Read exit ", h.p)
 	}
 	//TODO: snap.Open() should be called from minNode.Open() instead.
 	f, err := h.fs.snap.Open(h.p)
@@ -109,8 +109,8 @@ func (h *minHandle) ReadAt(data []byte, offset int64) (int, error) {
 
 func (h *minHandle) ReadDirAll() ([]fuse.Dirent, error) {
 	if Trace {
-		log.Info("Min: ReadDirAll entry ", h.p)
-		defer log.Info("Min: ReadDirAll exit ", h.p)
+		log.Debug("Min: ReadDirAll entry ", h.p)
+		defer log.Debug("Min: ReadDirAll exit ", h.p)
 	}
 	dirents, err := h.fs.snap.Readdirents(h.p)
 	if err != nil {

--- a/fs/minfuse/fs.go
+++ b/fs/minfuse/fs.go
@@ -1,8 +1,8 @@
 package minfuse
 
 import (
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"os"
 	"syscall"
 	"time"
@@ -55,8 +55,8 @@ func (n *minNode) Readlink() (string, error) {
 
 func (n *minNode) Lookup(name string) (fs.Node, error) {
 	if Trace {
-		log.Print("Min: Lookup entry ", n.p, name)
-		defer log.Print("Min: Lookup exit ", n.p, name)
+		log.Info("Min: Lookup entry ", n.p, name)
+		defer log.Info("Min: Lookup exit ", n.p, name)
 	}
 
 	// minNode stores the joined path so pass discards=false.
@@ -77,8 +77,8 @@ func (n *minNode) Lookup(name string) (fs.Node, error) {
 
 func (n *minNode) Open() (fs.Handle, error) {
 	if Trace {
-		log.Print("Min: Open entry ", n.p)
-		defer log.Print("Min: Open exit ", n.p)
+		log.Info("Min: Open entry ", n.p)
+		defer log.Info("Min: Open exit ", n.p)
 	}
 	return &minHandle{n.fs, n.p}, nil
 }
@@ -94,8 +94,8 @@ func (h *minHandle) Release() error {
 
 func (h *minHandle) ReadAt(data []byte, offset int64) (int, error) {
 	if Trace {
-		log.Print("Min: Read entry ", h.p)
-		defer log.Print("Min: Read exit ", h.p)
+		log.Info("Min: Read entry ", h.p)
+		defer log.Info("Min: Read exit ", h.p)
 	}
 	//TODO: snap.Open() should be called from minNode.Open() instead.
 	f, err := h.fs.snap.Open(h.p)
@@ -109,8 +109,8 @@ func (h *minHandle) ReadAt(data []byte, offset int64) (int, error) {
 
 func (h *minHandle) ReadDirAll() ([]fuse.Dirent, error) {
 	if Trace {
-		log.Print("Min: ReadDirAll entry ", h.p)
-		defer log.Print("Min: ReadDirAll exit ", h.p)
+		log.Info("Min: ReadDirAll entry ", h.p)
+		defer log.Info("Min: ReadDirAll exit ", h.p)
 	}
 	dirents, err := h.fs.snap.Readdirents(h.p)
 	if err != nil {

--- a/fs/minfuse/fs.go
+++ b/fs/minfuse/fs.go
@@ -1,7 +1,7 @@
 package minfuse
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"os"
 	"syscall"

--- a/fs/minfuse/runfs.go
+++ b/fs/minfuse/runfs.go
@@ -3,7 +3,7 @@ package minfuse
 import (
 	"errors"
 	"flag"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"net/http"
 	"os"
 	"os/signal"

--- a/fs/minfuse/runfs.go
+++ b/fs/minfuse/runfs.go
@@ -3,7 +3,7 @@ package minfuse
 import (
 	"errors"
 	"flag"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"net/http"
 	"os"
 	"os/signal"

--- a/fs/minfuse/runfs.go
+++ b/fs/minfuse/runfs.go
@@ -81,7 +81,7 @@ func InitFlags() (*Options, error) {
 		}
 	}
 	// TODO(rcouto): define String() method on opts for logging
-	// log.Info(opts)
+	// log.Debug(opts)
 	return &opts, nil
 }
 
@@ -106,7 +106,7 @@ func Runfs(opts *Options) {
 		options = append(options, fuse.AsyncRead())
 	}
 
-	log.Info("About to Mount")
+	log.Debug("About to Mount")
 	fuse.Unmount(opts.Mountpoint)
 	conn, err := fuse.Mount(opts.Mountpoint, fuse.MakeAlloc(), options...)
 	if err != nil {
@@ -118,29 +118,29 @@ func Runfs(opts *Options) {
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigchan
-		log.Info("Canceling")
+		log.Debug("Canceling")
 		if done != nil {
 			done <- errors.New("Caller canceled")
 		}
 	}()
 
 	go func() {
-		log.Info("pprof exit: ", http.ListenAndServe("localhost:6060", nil))
+		log.Debug("pprof exit: ", http.ListenAndServe("localhost:6060", nil))
 	}()
 
 	defer func() {
 		if err := fuse.Unmount(opts.Mountpoint); err != nil {
-			log.Info("error in call to Unmount(%s): %s", opts.Mountpoint, err)
+			log.Debug("error in call to Unmount(%s): %s", opts.Mountpoint, err)
 			return
 		}
-		log.Info("called Umount on %s", opts.Mountpoint)
+		log.Debug("called Umount on %s", opts.Mountpoint)
 	}()
 
 	// Serve returns immediately and we wait for the first entry from the done channel before exiting main.
 	// We only care about the first error from either the signal handler or from the first serve thread to return.
 	// Exiting main will cause the remaining read threads to exit.
-	log.Info("About to Serve")
+	log.Debug("About to Serve")
 	done = min.Serve(conn, minfs, opts.ThreadUnsafe)
 	err = <-done
-	log.Info("Returning (might take a few seconds), err=%v", err)
+	log.Debug("Returning (might take a few seconds), err=%v", err)
 }

--- a/fs/minfuse/runfs.go
+++ b/fs/minfuse/runfs.go
@@ -81,7 +81,7 @@ func InitFlags() (*Options, error) {
 		}
 	}
 	// TODO(rcouto): define String() method on opts for logging
-	// log.Debug(opts)
+	// log.Info(opts)
 	return &opts, nil
 }
 
@@ -106,7 +106,7 @@ func Runfs(opts *Options) {
 		options = append(options, fuse.AsyncRead())
 	}
 
-	log.Debug("About to Mount")
+	log.Info("About to Mount")
 	fuse.Unmount(opts.Mountpoint)
 	conn, err := fuse.Mount(opts.Mountpoint, fuse.MakeAlloc(), options...)
 	if err != nil {
@@ -118,29 +118,29 @@ func Runfs(opts *Options) {
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigchan
-		log.Debug("Canceling")
+		log.Info("Canceling")
 		if done != nil {
 			done <- errors.New("Caller canceled")
 		}
 	}()
 
 	go func() {
-		log.Debug("pprof exit: ", http.ListenAndServe("localhost:6060", nil))
+		log.Info("pprof exit: ", http.ListenAndServe("localhost:6060", nil))
 	}()
 
 	defer func() {
 		if err := fuse.Unmount(opts.Mountpoint); err != nil {
-			log.Debug("error in call to Unmount(%s): %s", opts.Mountpoint, err)
+			log.Info("error in call to Unmount(%s): %s", opts.Mountpoint, err)
 			return
 		}
-		log.Debug("called Umount on %s", opts.Mountpoint)
+		log.Info("called Umount on %s", opts.Mountpoint)
 	}()
 
 	// Serve returns immediately and we wait for the first entry from the done channel before exiting main.
 	// We only care about the first error from either the signal handler or from the first serve thread to return.
 	// Exiting main will cause the remaining read threads to exit.
-	log.Debug("About to Serve")
+	log.Info("About to Serve")
 	done = min.Serve(conn, minfs, opts.ThreadUnsafe)
 	err = <-done
-	log.Debug("Returning (might take a few seconds), err=%v", err)
+	log.Info("Returning (might take a few seconds), err=%v", err)
 }

--- a/fs/minfuse/runfs.go
+++ b/fs/minfuse/runfs.go
@@ -3,7 +3,7 @@ package minfuse
 import (
 	"errors"
 	"flag"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"net/http"
 	"os"
 	"os/signal"
@@ -29,7 +29,7 @@ type Options struct {
 }
 
 func SetupLog() {
-	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	// log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 }
 
 func InitFlags() (*Options, error) {
@@ -77,10 +77,11 @@ func InitFlags() (*Options, error) {
 			}
 			fallthrough
 		default:
-			log.Fatal("Unrecognized strategy", strategy)
+			log.Crit("Unrecognized strategy", strategy)
 		}
 	}
-	log.Print(opts)
+	// TODO(rcouto): define String() method on opts for logging
+	// log.Info(opts)
 	return &opts, nil
 }
 
@@ -105,11 +106,11 @@ func Runfs(opts *Options) {
 		options = append(options, fuse.AsyncRead())
 	}
 
-	log.Print("About to Mount")
+	log.Info("About to Mount")
 	fuse.Unmount(opts.Mountpoint)
 	conn, err := fuse.Mount(opts.Mountpoint, fuse.MakeAlloc(), options...)
 	if err != nil {
-		log.Fatal("Couldn't mount", err)
+		log.Crit("Couldn't mount", err)
 	}
 
 	var done chan error
@@ -117,29 +118,29 @@ func Runfs(opts *Options) {
 	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigchan
-		log.Printf("Canceling")
+		log.Info("Canceling")
 		if done != nil {
 			done <- errors.New("Caller canceled")
 		}
 	}()
 
 	go func() {
-		log.Println("pprof exit: ", http.ListenAndServe("localhost:6060", nil))
+		log.Info("pprof exit: ", http.ListenAndServe("localhost:6060", nil))
 	}()
 
 	defer func() {
 		if err := fuse.Unmount(opts.Mountpoint); err != nil {
-			log.Printf("error in call to Unmount(%s): %s", opts.Mountpoint, err)
+			log.Info("error in call to Unmount(%s): %s", opts.Mountpoint, err)
 			return
 		}
-		log.Printf("called Umount on %s", opts.Mountpoint)
+		log.Info("called Umount on %s", opts.Mountpoint)
 	}()
 
 	// Serve returns immediately and we wait for the first entry from the done channel before exiting main.
 	// We only care about the first error from either the signal handler or from the first serve thread to return.
 	// Exiting main will cause the remaining read threads to exit.
-	log.Print("About to Serve")
+	log.Info("About to Serve")
 	done = min.Serve(conn, minfs, opts.ThreadUnsafe)
 	err = <-done
-	log.Printf("Returning (might take a few seconds), err=%v", err)
+	log.Info("Returning (might take a few seconds), err=%v", err)
 }

--- a/fuse/connection.go
+++ b/fuse/connection.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"log"
+	log "github.com/inconshreveable/log15"
 	"syscall"
 	"unsafe"
 )
@@ -202,7 +202,7 @@ func (c *Conn) read(b []byte) (int, error) {
 	for {
 		n, err := syscall.Read(c.fd(), b)
 		if err != nil {
-			log.Println("read.err ", n, err)
+			log.Info("read.err ", n, err)
 		}
 		if err == syscall.EINTR {
 			// OSXFUSE sends EINTR to userspace when a request interrupt
@@ -256,7 +256,7 @@ func (c *Conn) writeToKernel(msg []byte) error {
 	out.len = uint32(len(msg))
 
 	if Trace {
-		log.Print("fuse done")
+		log.Info("fuse done")
 	}
 	nn, err := syscall.Write(c.fd(), msg)
 	if err == nil && nn != len(msg) {

--- a/fuse/connection.go
+++ b/fuse/connection.go
@@ -202,7 +202,7 @@ func (c *Conn) read(b []byte) (int, error) {
 	for {
 		n, err := syscall.Read(c.fd(), b)
 		if err != nil {
-			log.Info("read.err ", n, err)
+			log.Debug("read.err ", n, err)
 		}
 		if err == syscall.EINTR {
 			// OSXFUSE sends EINTR to userspace when a request interrupt
@@ -256,7 +256,7 @@ func (c *Conn) writeToKernel(msg []byte) error {
 	out.len = uint32(len(msg))
 
 	if Trace {
-		log.Info("fuse done")
+		log.Debug("fuse done")
 	}
 	nn, err := syscall.Write(c.fd(), msg)
 	if err == nil && nn != len(msg) {

--- a/fuse/connection.go
+++ b/fuse/connection.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"syscall"
 	"unsafe"
 )

--- a/fuse/connection.go
+++ b/fuse/connection.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"syscall"
 	"unsafe"
 )

--- a/fuse/connection.go
+++ b/fuse/connection.go
@@ -202,7 +202,7 @@ func (c *Conn) read(b []byte) (int, error) {
 	for {
 		n, err := syscall.Read(c.fd(), b)
 		if err != nil {
-			log.Debug("read.err ", n, err)
+			log.Info("read.err ", n, err)
 		}
 		if err == syscall.EINTR {
 			// OSXFUSE sends EINTR to userspace when a request interrupt
@@ -256,7 +256,7 @@ func (c *Conn) writeToKernel(msg []byte) error {
 	out.len = uint32(len(msg))
 
 	if Trace {
-		log.Debug("fuse done")
+		log.Info("fuse done")
 	}
 	nn, err := syscall.Write(c.fd(), msg)
 	if err == nil && nn != len(msg) {

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -66,7 +66,7 @@ package fuse // import "github.com/scootdev/scoot/fuse"
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"syscall"
 	"time"

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -66,7 +66,7 @@ package fuse // import "github.com/scootdev/scoot/fuse"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"syscall"
 	"time"
@@ -270,7 +270,7 @@ func processBuf(b []byte, scope *RequestScope, handler Servlet) (req Request, re
 			handleErr = handler.HandleRelease(req.(*ReleaseRequest), resp.(*ReleaseResponse))
 		}
 	default:
-		log.Printf("Unknown request type %v", h.opcode)
+		log.Info("Unknown request type %v", h.opcode)
 		return nil, nil, fmt.Errorf("Not implemented")
 	}
 

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -270,7 +270,7 @@ func processBuf(b []byte, scope *RequestScope, handler Servlet) (req Request, re
 			handleErr = handler.HandleRelease(req.(*ReleaseRequest), resp.(*ReleaseResponse))
 		}
 	default:
-		log.Info("Unknown request type %v", h.opcode)
+		log.Debug("Unknown request type %v", h.opcode)
 		return nil, nil, fmt.Errorf("Not implemented")
 	}
 

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -270,7 +270,7 @@ func processBuf(b []byte, scope *RequestScope, handler Servlet) (req Request, re
 			handleErr = handler.HandleRelease(req.(*ReleaseRequest), resp.(*ReleaseResponse))
 		}
 	default:
-		log.Debug("Unknown request type %v", h.opcode)
+		log.Info("Unknown request type %v", h.opcode)
 		return nil, nil, fmt.Errorf("Not implemented")
 	}
 

--- a/fuse/fuse.go
+++ b/fuse/fuse.go
@@ -66,7 +66,7 @@ package fuse // import "github.com/scootdev/scoot/fuse"
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"syscall"
 	"time"

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -30,9 +30,9 @@ func lineLogger(wg *sync.WaitGroup, prefix string, ignore func(line string) bool
 		if ignore(line) {
 			continue
 		}
-		log.Debug("%s: %s", prefix, line)
+		log.Info("%s: %s", prefix, line)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Debug("%s, error reading: %v", prefix, err)
+		log.Info("%s, error reading: %v", prefix, err)
 	}
 }

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -3,8 +3,8 @@ package fuse
 import (
 	"bufio"
 	"errors"
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"sync"
 )
 
@@ -30,9 +30,9 @@ func lineLogger(wg *sync.WaitGroup, prefix string, ignore func(line string) bool
 		if ignore(line) {
 			continue
 		}
-		log.Printf("%s: %s", prefix, line)
+		log.Info("%s: %s", prefix, line)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Printf("%s, error reading: %v", prefix, err)
+		log.Info("%s, error reading: %v", prefix, err)
 	}
 }

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -3,7 +3,7 @@ package fuse
 import (
 	"bufio"
 	"errors"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"sync"
 )

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -3,7 +3,7 @@ package fuse
 import (
 	"bufio"
 	"errors"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"sync"
 )

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -30,9 +30,9 @@ func lineLogger(wg *sync.WaitGroup, prefix string, ignore func(line string) bool
 		if ignore(line) {
 			continue
 		}
-		log.Info("%s: %s", prefix, line)
+		log.Debug("%s: %s", prefix, line)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Info("%s, error reading: %v", prefix, err)
+		log.Debug("%s, error reading: %v", prefix, err)
 	}
 }

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -146,7 +146,7 @@ func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *o
 			case helperErr := <-helperErrCh:
 				// log the Wait error if it's not what we expected
 				if !isBoringMountOSXFUSEError(err) {
-					log.Debug("mount helper failed: %v", err)
+					log.Info("mount helper failed: %v", err)
 				}
 				// and now return what we grabbed from stderr as the real
 				// error

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -3,7 +3,7 @@ package fuse
 import (
 	"errors"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"os/exec"
 	"path"

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -146,7 +146,7 @@ func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *o
 			case helperErr := <-helperErrCh:
 				// log the Wait error if it's not what we expected
 				if !isBoringMountOSXFUSEError(err) {
-					log.Info("mount helper failed: %v", err)
+					log.Debug("mount helper failed: %v", err)
 				}
 				// and now return what we grabbed from stderr as the real
 				// error

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -3,7 +3,7 @@ package fuse
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"os/exec"
 	"path"
@@ -146,7 +146,7 @@ func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *o
 			case helperErr := <-helperErrCh:
 				// log the Wait error if it's not what we expected
 				if !isBoringMountOSXFUSEError(err) {
-					log.Printf("mount helper failed: %v", err)
+					log.Info("mount helper failed: %v", err)
 				}
 				// and now return what we grabbed from stderr as the real
 				// error

--- a/fuse/mount_darwin.go
+++ b/fuse/mount_darwin.go
@@ -3,7 +3,7 @@ package fuse
 import (
 	"errors"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"os/exec"
 	"path"

--- a/fuse/mount_freebsd.go
+++ b/fuse/mount_freebsd.go
@@ -95,7 +95,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (*
 		case helperErr := <-helperErrCh:
 			// log the Wait error if it's not what we expected
 			if !isBoringMountFusefsError(err) {
-				log.Info("mount helper failed: %v", err)
+				log.Debug("mount helper failed: %v", err)
 			}
 			// and now return what we grabbed from stderr as the real
 			// error

--- a/fuse/mount_freebsd.go
+++ b/fuse/mount_freebsd.go
@@ -95,7 +95,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (*
 		case helperErr := <-helperErrCh:
 			// log the Wait error if it's not what we expected
 			if !isBoringMountFusefsError(err) {
-				log.Debug("mount helper failed: %v", err)
+				log.Info("mount helper failed: %v", err)
 			}
 			// and now return what we grabbed from stderr as the real
 			// error

--- a/fuse/mount_freebsd.go
+++ b/fuse/mount_freebsd.go
@@ -2,7 +2,7 @@ package fuse
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"os/exec"
 	"strings"

--- a/fuse/mount_freebsd.go
+++ b/fuse/mount_freebsd.go
@@ -2,7 +2,7 @@ package fuse
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"os/exec"
 	"strings"

--- a/fuse/mount_freebsd.go
+++ b/fuse/mount_freebsd.go
@@ -2,7 +2,7 @@ package fuse
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"os/exec"
 	"strings"
@@ -95,7 +95,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (*
 		case helperErr := <-helperErrCh:
 			// log the Wait error if it's not what we expected
 			if !isBoringMountFusefsError(err) {
-				log.Printf("mount helper failed: %v", err)
+				log.Info("mount helper failed: %v", err)
 			}
 			// and now return what we grabbed from stderr as the real
 			// error

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -2,7 +2,7 @@ package fuse
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"net"
 	"os"
 	"os/exec"
@@ -104,7 +104,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (f
 		case helperErr := <-helperErrCh:
 			// log the Wait error if it's not what we expected
 			if !isBoringFusermountError(err) {
-				log.Printf("mount helper failed: %v", err)
+				log.Info("mount helper failed: %v", err)
 			}
 			// and now return what we grabbed from stderr as the real
 			// error

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -2,7 +2,7 @@ package fuse
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"net"
 	"os"
 	"os/exec"

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -104,7 +104,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (f
 		case helperErr := <-helperErrCh:
 			// log the Wait error if it's not what we expected
 			if !isBoringFusermountError(err) {
-				log.Debug("mount helper failed: %v", err)
+				log.Info("mount helper failed: %v", err)
 			}
 			// and now return what we grabbed from stderr as the real
 			// error

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -2,7 +2,7 @@ package fuse
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"net"
 	"os"
 	"os/exec"

--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -104,7 +104,7 @@ func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (f
 		case helperErr := <-helperErrCh:
 			// log the Wait error if it's not what we expected
 			if !isBoringFusermountError(err) {
-				log.Info("mount helper failed: %v", err)
+				log.Debug("mount helper failed: %v", err)
 			}
 			// and now return what we grabbed from stderr as the real
 			// error

--- a/ice/eval.go
+++ b/ice/eval.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"reflect"
 	"runtime"
 	"runtime/debug"

--- a/ice/eval.go
+++ b/ice/eval.go
@@ -36,8 +36,8 @@ func (bag *MagicBag) Extract(dest interface{}) (result error) {
 	targetVal.Set(reflect.Value(eval.construct(targetType)))
 
 	s := spew.Sdump(dest)
-	log.Debug("************* Extracted:")
-	log.Debug(s)
+	log.Info("************* Extracted:")
+	log.Info(s)
 	return nil
 }
 

--- a/ice/eval.go
+++ b/ice/eval.go
@@ -36,8 +36,8 @@ func (bag *MagicBag) Extract(dest interface{}) (result error) {
 	targetVal.Set(reflect.Value(eval.construct(targetType)))
 
 	s := spew.Sdump(dest)
-	log.Info("************* Extracted:")
-	log.Info(s)
+	log.Debug("************* Extracted:")
+	log.Debug(s)
 	return nil
 }
 

--- a/ice/eval.go
+++ b/ice/eval.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"reflect"
 	"runtime"
 	"runtime/debug"

--- a/ice/eval.go
+++ b/ice/eval.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -36,8 +36,8 @@ func (bag *MagicBag) Extract(dest interface{}) (result error) {
 	targetVal.Set(reflect.Value(eval.construct(targetType)))
 
 	s := spew.Sdump(dest)
-	log.Println("************* Extracted:")
-	log.Println(s)
+	log.Info("************* Extracted:")
+	log.Info(s)
 	return nil
 }
 

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -53,7 +53,7 @@ func (inv *Invoker) Run(cmd *runner.Command, id runner.RunID) (abortCh chan<- st
 // Run will not return until the process is not running.
 // NOTE: kind of gnarly since our filer implementation (gitdb) currently mutates the same worktree on every op.
 func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struct{}, updateCh chan runner.RunStatus) (r runner.RunStatus) {
-	log.Info("run. id: %v, cmd: %+v", id, cmd)
+	log.Debug("run. id: %v, cmd: %+v", id, cmd)
 	defer func() {
 		updateCh <- r
 		close(updateCh)
@@ -65,7 +65,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		if cmd.SnapshotID == "" {
 			//TODO: we don't want this logic to live here, these decisions should be made at a higher level.
 			if len(cmd.Argv) > 0 && cmd.Argv[0] != execers.UseSimExecerArg {
-				log.Info("RunID:%s has no snapshotID! Using a nop-checkout initialized with tmpDir.\n", id)
+				log.Debug("RunID:%s has no snapshotID! Using a nop-checkout initialized with tmpDir.\n", id)
 			}
 			if tmp, err := inv.tmp.TempDir("invoke_nop_checkout"); err != nil {
 				checkoutCh <- err
@@ -75,7 +75,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			}
 		} else {
 			//NOTE: given the current gitdb impl, this checkout will block until the previous checkout is released.
-			log.Info("RunID:%s checking out snapshotID:%s", id, cmd.SnapshotID)
+			log.Debug("RunID:%s checking out snapshotID:%s", id, cmd.SnapshotID)
 			var err error
 			co, err = inv.filer.Checkout(cmd.SnapshotID)
 			checkoutCh <- err
@@ -100,7 +100,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		// Checkout is ok, continue with run and when finished release checkout.
 		defer co.Release()
 	}
-	log.Info("checkout done. id: %v, cmd: %+v, checkout: %v", id, cmd, co.Path())
+	log.Debug("checkout done. id: %v, cmd: %+v, checkout: %v", id, cmd, co.Path())
 
 	stdout, err := inv.output.Create(fmt.Sprintf("%s-stdout", id))
 	if err != nil {
@@ -118,7 +118,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	format := "%s\n\nDate: %v\nSelf: %s\tCmd:\n%v\n\n%s\n\n\nSCOOT_CMD_LOG\n"
 	stdout.Write([]byte(fmt.Sprintf(format, marker, time.Now(), stdout.URI(), cmd, marker)))
 	stderr.Write([]byte(fmt.Sprintf(format, marker, time.Now(), stderr.URI(), cmd, marker)))
-	log.Info("RunID: %s, stdout: %s, stderr: %s\n", id, stdout.AsFile(), stderr.AsFile())
+	log.Debug("RunID: %s, stdout: %s, stderr: %s\n", id, stdout.AsFile(), stderr.AsFile())
 
 	p, err := inv.exec.Exec(execer.Command{
 		Argv:   cmd.Argv,
@@ -154,7 +154,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	case st = <-processCh:
 	}
 
-	log.Info("run done. id: %v, status: %+v, cmd: %+v, checkout: %v", id, st, cmd, co.Path())
+	log.Debug("run done. id: %v, status: %+v, cmd: %+v, checkout: %v", id, st, cmd, co.Path())
 
 	switch st.State {
 	case execer.COMPLETE:

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -2,7 +2,7 @@ package runners
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"os"
 	"path/filepath"

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -2,8 +2,8 @@ package runners
 
 import (
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -53,7 +53,7 @@ func (inv *Invoker) Run(cmd *runner.Command, id runner.RunID) (abortCh chan<- st
 // Run will not return until the process is not running.
 // NOTE: kind of gnarly since our filer implementation (gitdb) currently mutates the same worktree on every op.
 func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struct{}, updateCh chan runner.RunStatus) (r runner.RunStatus) {
-	log.Printf("run. id: %v, cmd: %+v", id, cmd)
+	log.Info("run. id: %v, cmd: %+v", id, cmd)
 	defer func() {
 		updateCh <- r
 		close(updateCh)
@@ -65,7 +65,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		if cmd.SnapshotID == "" {
 			//TODO: we don't want this logic to live here, these decisions should be made at a higher level.
 			if len(cmd.Argv) > 0 && cmd.Argv[0] != execers.UseSimExecerArg {
-				log.Printf("RunID:%s has no snapshotID! Using a nop-checkout initialized with tmpDir.\n", id)
+				log.Info("RunID:%s has no snapshotID! Using a nop-checkout initialized with tmpDir.\n", id)
 			}
 			if tmp, err := inv.tmp.TempDir("invoke_nop_checkout"); err != nil {
 				checkoutCh <- err
@@ -75,7 +75,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			}
 		} else {
 			//NOTE: given the current gitdb impl, this checkout will block until the previous checkout is released.
-			log.Printf("RunID:%s checking out snapshotID:%s", id, cmd.SnapshotID)
+			log.Info("RunID:%s checking out snapshotID:%s", id, cmd.SnapshotID)
 			var err error
 			co, err = inv.filer.Checkout(cmd.SnapshotID)
 			checkoutCh <- err
@@ -100,7 +100,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		// Checkout is ok, continue with run and when finished release checkout.
 		defer co.Release()
 	}
-	log.Printf("checkout done. id: %v, cmd: %+v, checkout: %v", id, cmd, co.Path())
+	log.Info("checkout done. id: %v, cmd: %+v, checkout: %v", id, cmd, co.Path())
 
 	stdout, err := inv.output.Create(fmt.Sprintf("%s-stdout", id))
 	if err != nil {
@@ -118,7 +118,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	format := "%s\n\nDate: %v\nSelf: %s\tCmd:\n%v\n\n%s\n\n\nSCOOT_CMD_LOG\n"
 	stdout.Write([]byte(fmt.Sprintf(format, marker, time.Now(), stdout.URI(), cmd, marker)))
 	stderr.Write([]byte(fmt.Sprintf(format, marker, time.Now(), stderr.URI(), cmd, marker)))
-	log.Printf("RunID: %s, stdout: %s, stderr: %s\n", id, stdout.AsFile(), stderr.AsFile())
+	log.Info("RunID: %s, stdout: %s, stderr: %s\n", id, stdout.AsFile(), stderr.AsFile())
 
 	p, err := inv.exec.Exec(execer.Command{
 		Argv:   cmd.Argv,
@@ -154,7 +154,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	case st = <-processCh:
 	}
 
-	log.Printf("run done. id: %v, status: %+v, cmd: %+v, checkout: %v", id, st, cmd, co.Path())
+	log.Info("run done. id: %v, status: %+v, cmd: %+v, checkout: %v", id, st, cmd, co.Path())
 
 	switch st.State {
 	case execer.COMPLETE:

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -2,7 +2,7 @@ package runners
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"os"
 	"path/filepath"

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -53,7 +53,7 @@ func (inv *Invoker) Run(cmd *runner.Command, id runner.RunID) (abortCh chan<- st
 // Run will not return until the process is not running.
 // NOTE: kind of gnarly since our filer implementation (gitdb) currently mutates the same worktree on every op.
 func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struct{}, updateCh chan runner.RunStatus) (r runner.RunStatus) {
-	log.Debug("run. id: %v, cmd: %+v", id, cmd)
+	log.Info("run. id: %v, cmd: %+v", id, cmd)
 	defer func() {
 		updateCh <- r
 		close(updateCh)
@@ -65,7 +65,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		if cmd.SnapshotID == "" {
 			//TODO: we don't want this logic to live here, these decisions should be made at a higher level.
 			if len(cmd.Argv) > 0 && cmd.Argv[0] != execers.UseSimExecerArg {
-				log.Debug("RunID:%s has no snapshotID! Using a nop-checkout initialized with tmpDir.\n", id)
+				log.Info("RunID:%s has no snapshotID! Using a nop-checkout initialized with tmpDir.\n", id)
 			}
 			if tmp, err := inv.tmp.TempDir("invoke_nop_checkout"); err != nil {
 				checkoutCh <- err
@@ -75,7 +75,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 			}
 		} else {
 			//NOTE: given the current gitdb impl, this checkout will block until the previous checkout is released.
-			log.Debug("RunID:%s checking out snapshotID:%s", id, cmd.SnapshotID)
+			log.Info("RunID:%s checking out snapshotID:%s", id, cmd.SnapshotID)
 			var err error
 			co, err = inv.filer.Checkout(cmd.SnapshotID)
 			checkoutCh <- err
@@ -100,7 +100,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		// Checkout is ok, continue with run and when finished release checkout.
 		defer co.Release()
 	}
-	log.Debug("checkout done. id: %v, cmd: %+v, checkout: %v", id, cmd, co.Path())
+	log.Info("checkout done. id: %v, cmd: %+v, checkout: %v", id, cmd, co.Path())
 
 	stdout, err := inv.output.Create(fmt.Sprintf("%s-stdout", id))
 	if err != nil {
@@ -118,7 +118,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	format := "%s\n\nDate: %v\nSelf: %s\tCmd:\n%v\n\n%s\n\n\nSCOOT_CMD_LOG\n"
 	stdout.Write([]byte(fmt.Sprintf(format, marker, time.Now(), stdout.URI(), cmd, marker)))
 	stderr.Write([]byte(fmt.Sprintf(format, marker, time.Now(), stderr.URI(), cmd, marker)))
-	log.Debug("RunID: %s, stdout: %s, stderr: %s\n", id, stdout.AsFile(), stderr.AsFile())
+	log.Info("RunID: %s, stdout: %s, stderr: %s\n", id, stdout.AsFile(), stderr.AsFile())
 
 	p, err := inv.exec.Exec(execer.Command{
 		Argv:   cmd.Argv,
@@ -154,7 +154,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	case st = <-processCh:
 	}
 
-	log.Debug("run done. id: %v, status: %+v, cmd: %+v, checkout: %v", id, st, cmd, co.Path())
+	log.Info("run done. id: %v, status: %+v, cmd: %+v, checkout: %v", id, st, cmd, co.Path())
 
 	switch st.State {
 	case execer.COMPLETE:

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -99,7 +99,7 @@ func (c *QueueController) start(cmd *runner.Command, id runner.RunID) {
 
 func (c *QueueController) watch(updateCh <-chan runner.RunStatus) {
 	for st := range updateCh {
-		log.Info("Queue pulled result:%+v\n", st)
+		log.Debug("Queue pulled result:%+v\n", st)
 		if st.State.IsDone() {
 			c.mu.Lock()
 			defer c.mu.Unlock()
@@ -108,7 +108,7 @@ func (c *QueueController) watch(updateCh <-chan runner.RunStatus) {
 			if len(c.queue) > 0 {
 				cmdAndID := c.queue[0]
 				c.queue = c.queue[1:]
-				log.Info("Running from queue:%+v\n", cmdAndID)
+				log.Debug("Running from queue:%+v\n", cmdAndID)
 				c.start(cmdAndID.cmd, cmdAndID.id)
 			}
 		}

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -99,7 +99,7 @@ func (c *QueueController) start(cmd *runner.Command, id runner.RunID) {
 
 func (c *QueueController) watch(updateCh <-chan runner.RunStatus) {
 	for st := range updateCh {
-		log.Debug("Queue pulled result:%+v\n", st)
+		log.Info("Queue pulled result:%+v\n", st)
 		if st.State.IsDone() {
 			c.mu.Lock()
 			defer c.mu.Unlock()
@@ -108,7 +108,7 @@ func (c *QueueController) watch(updateCh <-chan runner.RunStatus) {
 			if len(c.queue) > 0 {
 				cmdAndID := c.queue[0]
 				c.queue = c.queue[1:]
-				log.Debug("Running from queue:%+v\n", cmdAndID)
+				log.Info("Running from queue:%+v\n", cmdAndID)
 				c.start(cmdAndID.cmd, cmdAndID.id)
 			}
 		}

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
@@ -99,7 +99,7 @@ func (c *QueueController) start(cmd *runner.Command, id runner.RunID) {
 
 func (c *QueueController) watch(updateCh <-chan runner.RunStatus) {
 	for st := range updateCh {
-		log.Printf("Queue pulled result:%+v\n", st)
+		log.Info("Queue pulled result:%+v\n", st)
 		if st.State.IsDone() {
 			c.mu.Lock()
 			defer c.mu.Unlock()
@@ -108,7 +108,7 @@ func (c *QueueController) watch(updateCh <-chan runner.RunStatus) {
 			if len(c.queue) > 0 {
 				cmdAndID := c.queue[0]
 				c.queue = c.queue[1:]
-				log.Printf("Running from queue:%+v\n", cmdAndID)
+				log.Info("Running from queue:%+v\n", cmdAndID)
 				c.start(cmdAndID.cmd, cmdAndID.id)
 			}
 		}

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -68,13 +68,13 @@ func (s *StatusManager) Update(newStatus runner.RunStatus) error {
 		newStatus.StderrRef = oldStatus.StderrRef
 	}
 
-	log.Info("StatusManager is holding status:%+v", newStatus)
+	log.Debug("StatusManager is holding status:%+v", newStatus)
 	s.runs[newStatus.RunID] = newStatus
 
 	listeners := make([]queryAndCh, 0, len(s.listeners))
 	for _, listener := range s.listeners {
 		if listener.q.Matches(newStatus) {
-			log.Info("StatusManager putting status %+v on listener channel\n", newStatus)
+			log.Debug("StatusManager putting status %+v on listener channel\n", newStatus)
 			listener.ch <- newStatus
 			close(listener.ch)
 		} else {

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -68,13 +68,13 @@ func (s *StatusManager) Update(newStatus runner.RunStatus) error {
 		newStatus.StderrRef = oldStatus.StderrRef
 	}
 
-	log.Debug("StatusManager is holding status:%+v", newStatus)
+	log.Info("StatusManager is holding status:%+v", newStatus)
 	s.runs[newStatus.RunID] = newStatus
 
 	listeners := make([]queryAndCh, 0, len(s.listeners))
 	for _, listener := range s.listeners {
 		if listener.q.Matches(newStatus) {
-			log.Debug("StatusManager putting status %+v on listener channel\n", newStatus)
+			log.Info("StatusManager putting status %+v on listener channel\n", newStatus)
 			listener.ch <- newStatus
 			close(listener.ch)
 		} else {

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"github.com/scootdev/scoot/runner"
 )
 

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"github.com/scootdev/scoot/runner"
 )
 

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/inconshreveable/log15"
 	"github.com/scootdev/scoot/runner"
-	"log"
 )
 
 const UnknownRunIDMsg = "unknown run id %v"
@@ -68,13 +68,13 @@ func (s *StatusManager) Update(newStatus runner.RunStatus) error {
 		newStatus.StderrRef = oldStatus.StderrRef
 	}
 
-	log.Printf("StatusManager is holding status:%+v", newStatus)
+	log.Info("StatusManager is holding status:%+v", newStatus)
 	s.runs[newStatus.RunID] = newStatus
 
 	listeners := make([]queryAndCh, 0, len(s.listeners))
 	for _, listener := range s.listeners {
 		if listener.q.Matches(newStatus) {
-			log.Printf("StatusManager putting status %+v on listener channel\n", newStatus)
+			log.Info("StatusManager putting status %+v on listener channel\n", newStatus)
 			listener.ch <- newStatus
 			close(listener.ch)
 		} else {

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/scootdev/scoot/cloud/cluster"
 )
@@ -113,10 +113,10 @@ func (c *clusterState) update(updates []cluster.NodeUpdate) {
 			if _, ok := c.nodes[update.Node.Id()]; !ok {
 				c.nodes[update.Node.Id()] = newNodeState(update.Node)
 				c.nodeGroups[""].idle[update.Node.Id()] = update.Node
-				log.Printf("Added node: %+v, now have %d nodes\n", update.Node, len(c.nodes))
+				log.Info("Added node: %+v, now have %d nodes\n", update.Node, len(c.nodes))
 			}
 		case cluster.NodeRemoved:
-			log.Printf("Removed nodeId: %s (%v), now have %d nodes\n", string(update.Id), c.nodes[update.Id], len(c.nodes))
+			log.Info("Removed nodeId: %s (%v), now have %d nodes\n", string(update.Id), c.nodes[update.Id], len(c.nodes))
 			if nodeState, ok := c.nodes[update.Id]; ok {
 				delete(c.nodeGroups[nodeState.snapshotId].idle, update.Id)
 				delete(c.nodeGroups[nodeState.snapshotId].busy, update.Id)

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/scootdev/scoot/cloud/cluster"
 )

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -113,10 +113,10 @@ func (c *clusterState) update(updates []cluster.NodeUpdate) {
 			if _, ok := c.nodes[update.Node.Id()]; !ok {
 				c.nodes[update.Node.Id()] = newNodeState(update.Node)
 				c.nodeGroups[""].idle[update.Node.Id()] = update.Node
-				log.Debug("Added node: %+v, now have %d nodes\n", update.Node, len(c.nodes))
+				log.Info("Added node: %+v, now have %d nodes\n", update.Node, len(c.nodes))
 			}
 		case cluster.NodeRemoved:
-			log.Debug("Removed nodeId: %s (%v), now have %d nodes\n", string(update.Id), c.nodes[update.Id], len(c.nodes))
+			log.Info("Removed nodeId: %s (%v), now have %d nodes\n", string(update.Id), c.nodes[update.Id], len(c.nodes))
 			if nodeState, ok := c.nodes[update.Id]; ok {
 				delete(c.nodeGroups[nodeState.snapshotId].idle, update.Id)
 				delete(c.nodeGroups[nodeState.snapshotId].busy, update.Id)

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/scootdev/scoot/cloud/cluster"
 )

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -113,10 +113,10 @@ func (c *clusterState) update(updates []cluster.NodeUpdate) {
 			if _, ok := c.nodes[update.Node.Id()]; !ok {
 				c.nodes[update.Node.Id()] = newNodeState(update.Node)
 				c.nodeGroups[""].idle[update.Node.Id()] = update.Node
-				log.Info("Added node: %+v, now have %d nodes\n", update.Node, len(c.nodes))
+				log.Debug("Added node: %+v, now have %d nodes\n", update.Node, len(c.nodes))
 			}
 		case cluster.NodeRemoved:
-			log.Info("Removed nodeId: %s (%v), now have %d nodes\n", string(update.Id), c.nodes[update.Id], len(c.nodes))
+			log.Debug("Removed nodeId: %s (%v), now have %d nodes\n", string(update.Id), c.nodes[update.Id], len(c.nodes))
 			if nodeState, ok := c.nodes[update.Id]; ok {
 				delete(c.nodeGroups[nodeState.snapshotId].idle, update.Id)
 				delete(c.nodeGroups[nodeState.snapshotId].busy, update.Id)

--- a/sched/scheduler/recover_jobs.go
+++ b/sched/scheduler/recover_jobs.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"math"
 	"sync"
 	"time"
@@ -14,7 +14,7 @@ import (
 // ActiveSagas are recovered in parallel and are added to the addJobCh to be rescheduled
 // This method returns once all activeSagas have been successfully recovered.
 func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
-	log.Printf("INFO: Recovering Sagas")
+	log.Info("INFO: Recovering Sagas")
 
 	recoveryActiveSagaAttempts := 0
 	activeSagas, err := sc.Startup()
@@ -23,7 +23,7 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 		// for us to make progress.
 		// TODO: Add metrics for failure rate, this would be something we should alert on.
 		recoveryActiveSagaAttempts++
-		log.Printf("ERROR: occurred getting ActiveSagas from SagaLog %v", err)
+		log.Info("ERROR: occurred getting ActiveSagas from SagaLog %v", err)
 
 		delay := calculateExponentialBackoff(recoveryActiveSagaAttempts, time.Duration(1)*time.Minute)
 		time.Sleep(delay)
@@ -35,7 +35,7 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 		return
 	}
 
-	log.Printf("DEBUG: Recovering Active Sagas %+v", activeSagas)
+	log.Info("DEBUG: Recovering Active Sagas %+v", activeSagas)
 
 	var wg sync.WaitGroup
 	wg.Add(len(activeSagas))
@@ -53,11 +53,11 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 				if err != nil {
 					// TODO: Increment counter? A breaking change was made
 					// if this happens or data was corrupted.
-					log.Printf("Error: Could not deserialize Job for Saga %v, error: %v", sagaId, err)
+					log.Info("Error: Could not deserialize Job for Saga %v, error: %v", sagaId, err)
 					return
 				}
 
-				log.Printf("INFO: Rescheduling Saga %v", sagaId)
+				log.Info("INFO: Rescheduling Saga %v", sagaId)
 				// reschedule saga
 				addJobCh <- jobAddedMsg{
 					job:  job,
@@ -87,14 +87,14 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 		if saga.FatalErr(err) {
 			// TODO: add metrics for fatal failure rate, this would be something we should alert on, this is a bad bug
 			// if we can't recover the saga from the long, means something is very wrong.
-			log.Printf("ERROR: Fatal Error occurred recovering saga %v, with error: %v, skipping recovery for this saga", sagaId, err)
+			log.Info("ERROR: Fatal Error occurred recovering saga %v, with error: %v, skipping recovery for this saga", sagaId, err)
 			err = nil
 			activeSaga = nil
 		} else {
 			// Recovering SagaState must eventually succeed if it doesn't continue to retry with
 			// exponential backoff.
 			recoverSagaStateAttempts++
-			log.Printf("ERROR: occurred recovering Saga %v, from SagaLog %v", sagaId, err)
+			log.Info("ERROR: occurred recovering Saga %v, from SagaLog %v", sagaId, err)
 
 			delay := calculateExponentialBackoff(recoverSagaStateAttempts, time.Duration(1)*time.Minute)
 			time.Sleep(delay)
@@ -106,7 +106,7 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 	// This could happen because a Saga got added to active index, but failed to
 	// log successfully.  In this case Starting the Saga will have failed.
 	if activeSaga == nil {
-		log.Printf("DEBUG: Saga doesn't exist %v", sagaId)
+		log.Info("DEBUG: Saga doesn't exist %v", sagaId)
 		return nil
 	}
 
@@ -114,7 +114,7 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 	// This could happen because Active Index did not get updated successfully,
 	// even if the saga has been completed.
 	if activeSaga.GetState().IsSagaCompleted() {
-		log.Printf("DEBUG: Saga Already Completed %v", sagaId)
+		log.Info("DEBUG: Saga Already Completed %v", sagaId)
 		return nil
 	}
 

--- a/sched/scheduler/recover_jobs.go
+++ b/sched/scheduler/recover_jobs.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"math"
 	"sync"
 	"time"

--- a/sched/scheduler/recover_jobs.go
+++ b/sched/scheduler/recover_jobs.go
@@ -14,7 +14,7 @@ import (
 // ActiveSagas are recovered in parallel and are added to the addJobCh to be rescheduled
 // This method returns once all activeSagas have been successfully recovered.
 func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
-	log.Info("INFO: Recovering Sagas")
+	log.Debug("INFO: Recovering Sagas")
 
 	recoveryActiveSagaAttempts := 0
 	activeSagas, err := sc.Startup()
@@ -23,7 +23,7 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 		// for us to make progress.
 		// TODO: Add metrics for failure rate, this would be something we should alert on.
 		recoveryActiveSagaAttempts++
-		log.Info("ERROR: occurred getting ActiveSagas from SagaLog %v", err)
+		log.Debug("ERROR: occurred getting ActiveSagas from SagaLog %v", err)
 
 		delay := calculateExponentialBackoff(recoveryActiveSagaAttempts, time.Duration(1)*time.Minute)
 		time.Sleep(delay)
@@ -35,7 +35,7 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 		return
 	}
 
-	log.Info("DEBUG: Recovering Active Sagas %+v", activeSagas)
+	log.Debug("DEBUG: Recovering Active Sagas %+v", activeSagas)
 
 	var wg sync.WaitGroup
 	wg.Add(len(activeSagas))
@@ -53,11 +53,11 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 				if err != nil {
 					// TODO: Increment counter? A breaking change was made
 					// if this happens or data was corrupted.
-					log.Info("Error: Could not deserialize Job for Saga %v, error: %v", sagaId, err)
+					log.Debug("Error: Could not deserialize Job for Saga %v, error: %v", sagaId, err)
 					return
 				}
 
-				log.Info("INFO: Rescheduling Saga %v", sagaId)
+				log.Debug("INFO: Rescheduling Saga %v", sagaId)
 				// reschedule saga
 				addJobCh <- jobAddedMsg{
 					job:  job,
@@ -87,14 +87,14 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 		if saga.FatalErr(err) {
 			// TODO: add metrics for fatal failure rate, this would be something we should alert on, this is a bad bug
 			// if we can't recover the saga from the long, means something is very wrong.
-			log.Info("ERROR: Fatal Error occurred recovering saga %v, with error: %v, skipping recovery for this saga", sagaId, err)
+			log.Debug("ERROR: Fatal Error occurred recovering saga %v, with error: %v, skipping recovery for this saga", sagaId, err)
 			err = nil
 			activeSaga = nil
 		} else {
 			// Recovering SagaState must eventually succeed if it doesn't continue to retry with
 			// exponential backoff.
 			recoverSagaStateAttempts++
-			log.Info("ERROR: occurred recovering Saga %v, from SagaLog %v", sagaId, err)
+			log.Debug("ERROR: occurred recovering Saga %v, from SagaLog %v", sagaId, err)
 
 			delay := calculateExponentialBackoff(recoverSagaStateAttempts, time.Duration(1)*time.Minute)
 			time.Sleep(delay)
@@ -106,7 +106,7 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 	// This could happen because a Saga got added to active index, but failed to
 	// log successfully.  In this case Starting the Saga will have failed.
 	if activeSaga == nil {
-		log.Info("DEBUG: Saga doesn't exist %v", sagaId)
+		log.Debug("DEBUG: Saga doesn't exist %v", sagaId)
 		return nil
 	}
 
@@ -114,7 +114,7 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 	// This could happen because Active Index did not get updated successfully,
 	// even if the saga has been completed.
 	if activeSaga.GetState().IsSagaCompleted() {
-		log.Info("DEBUG: Saga Already Completed %v", sagaId)
+		log.Debug("DEBUG: Saga Already Completed %v", sagaId)
 		return nil
 	}
 

--- a/sched/scheduler/recover_jobs.go
+++ b/sched/scheduler/recover_jobs.go
@@ -14,7 +14,7 @@ import (
 // ActiveSagas are recovered in parallel and are added to the addJobCh to be rescheduled
 // This method returns once all activeSagas have been successfully recovered.
 func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
-	log.Debug("INFO: Recovering Sagas")
+	log.Info("INFO: Recovering Sagas")
 
 	recoveryActiveSagaAttempts := 0
 	activeSagas, err := sc.Startup()
@@ -23,7 +23,7 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 		// for us to make progress.
 		// TODO: Add metrics for failure rate, this would be something we should alert on.
 		recoveryActiveSagaAttempts++
-		log.Debug("ERROR: occurred getting ActiveSagas from SagaLog %v", err)
+		log.Info("ERROR: occurred getting ActiveSagas from SagaLog %v", err)
 
 		delay := calculateExponentialBackoff(recoveryActiveSagaAttempts, time.Duration(1)*time.Minute)
 		time.Sleep(delay)
@@ -35,7 +35,7 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 		return
 	}
 
-	log.Debug("DEBUG: Recovering Active Sagas %+v", activeSagas)
+	log.Info("DEBUG: Recovering Active Sagas %+v", activeSagas)
 
 	var wg sync.WaitGroup
 	wg.Add(len(activeSagas))
@@ -53,11 +53,11 @@ func recoverJobs(sc saga.SagaCoordinator, addJobCh chan jobAddedMsg) {
 				if err != nil {
 					// TODO: Increment counter? A breaking change was made
 					// if this happens or data was corrupted.
-					log.Debug("Error: Could not deserialize Job for Saga %v, error: %v", sagaId, err)
+					log.Info("Error: Could not deserialize Job for Saga %v, error: %v", sagaId, err)
 					return
 				}
 
-				log.Debug("INFO: Rescheduling Saga %v", sagaId)
+				log.Info("INFO: Rescheduling Saga %v", sagaId)
 				// reschedule saga
 				addJobCh <- jobAddedMsg{
 					job:  job,
@@ -87,14 +87,14 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 		if saga.FatalErr(err) {
 			// TODO: add metrics for fatal failure rate, this would be something we should alert on, this is a bad bug
 			// if we can't recover the saga from the long, means something is very wrong.
-			log.Debug("ERROR: Fatal Error occurred recovering saga %v, with error: %v, skipping recovery for this saga", sagaId, err)
+			log.Info("ERROR: Fatal Error occurred recovering saga %v, with error: %v, skipping recovery for this saga", sagaId, err)
 			err = nil
 			activeSaga = nil
 		} else {
 			// Recovering SagaState must eventually succeed if it doesn't continue to retry with
 			// exponential backoff.
 			recoverSagaStateAttempts++
-			log.Debug("ERROR: occurred recovering Saga %v, from SagaLog %v", sagaId, err)
+			log.Info("ERROR: occurred recovering Saga %v, from SagaLog %v", sagaId, err)
 
 			delay := calculateExponentialBackoff(recoverSagaStateAttempts, time.Duration(1)*time.Minute)
 			time.Sleep(delay)
@@ -106,7 +106,7 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 	// This could happen because a Saga got added to active index, but failed to
 	// log successfully.  In this case Starting the Saga will have failed.
 	if activeSaga == nil {
-		log.Debug("DEBUG: Saga doesn't exist %v", sagaId)
+		log.Info("DEBUG: Saga doesn't exist %v", sagaId)
 		return nil
 	}
 
@@ -114,7 +114,7 @@ func recoverSaga(sc saga.SagaCoordinator, sagaId string) *saga.Saga {
 	// This could happen because Active Index did not get updated successfully,
 	// even if the saga has been completed.
 	if activeSaga.GetState().IsSagaCompleted() {
-		log.Debug("DEBUG: Saga Already Completed %v", sagaId)
+		log.Info("DEBUG: Saga Already Completed %v", sagaId)
 		return nil
 	}
 

--- a/sched/scheduler/recover_jobs.go
+++ b/sched/scheduler/recover_jobs.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"math"
 	"sync"
 	"time"

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -242,7 +242,7 @@ func (s *statefulScheduler) checkForCompletedJobs() {
 				},
 				func(err error) {
 					if err == nil {
-						log.Info("Job %v Completed \n", j.Job.Id)
+						log.Debug("Job %v Completed \n", j.Job.Id)
 						// This job is fully processed remove from
 						// InProgressJobs
 						delete(s.inProgressJobs, j.Job.Id)
@@ -285,7 +285,7 @@ func (s *statefulScheduler) scheduleTasks() {
 
 		// Mark Task as Started
 		s.clusterState.taskScheduled(nodeId, taskId, taskDef.SnapshotID)
-		log.Info("job:%s, task:%s, scheduled on node:%s\n", jobId, taskId, nodeId)
+		log.Debug("job:%s, task:%s, scheduled on node:%s\n", jobId, taskId, nodeId)
 		jobState.taskStarted(taskId)
 
 		runner := &taskRunner{
@@ -307,7 +307,7 @@ func (s *statefulScheduler) scheduleTasks() {
 			func(err error) {
 				// update the jobState
 				if err == nil {
-					log.Info("Ending job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "))
+					log.Debug("Ending job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "))
 
 					jobState.taskCompleted(taskId)
 				} else {
@@ -315,13 +315,13 @@ func (s *statefulScheduler) scheduleTasks() {
 					if preventRetries {
 						retry = "(will not be retried)"
 					}
-					log.Info("Error running job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "), retry)
+					log.Debug("Error running job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "), retry)
 					jobState.errorRunningTask(taskId, err)
 				}
 
 				// update cluster state that this node is now free
 				s.clusterState.taskCompleted(nodeId, taskId)
-				log.Info("Freeing node:", nodeId, ", removed job:", jobId, ", task:", taskId)
+				log.Debug("Freeing node:", nodeId, ", removed job:", jobId, ", task:", taskId)
 			})
 	}
 }

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"strings"
 	"time"
 
@@ -242,7 +242,7 @@ func (s *statefulScheduler) checkForCompletedJobs() {
 				},
 				func(err error) {
 					if err == nil {
-						log.Printf("Job %v Completed \n", j.Job.Id)
+						log.Info("Job %v Completed \n", j.Job.Id)
 						// This job is fully processed remove from
 						// InProgressJobs
 						delete(s.inProgressJobs, j.Job.Id)
@@ -285,7 +285,7 @@ func (s *statefulScheduler) scheduleTasks() {
 
 		// Mark Task as Started
 		s.clusterState.taskScheduled(nodeId, taskId, taskDef.SnapshotID)
-		log.Printf("job:%s, task:%s, scheduled on node:%s\n", jobId, taskId, nodeId)
+		log.Info("job:%s, task:%s, scheduled on node:%s\n", jobId, taskId, nodeId)
 		jobState.taskStarted(taskId)
 
 		runner := &taskRunner{
@@ -307,7 +307,7 @@ func (s *statefulScheduler) scheduleTasks() {
 			func(err error) {
 				// update the jobState
 				if err == nil {
-					log.Println("Ending job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "))
+					log.Info("Ending job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "))
 
 					jobState.taskCompleted(taskId)
 				} else {
@@ -315,13 +315,13 @@ func (s *statefulScheduler) scheduleTasks() {
 					if preventRetries {
 						retry = "(will not be retried)"
 					}
-					log.Println("Error running job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "), retry)
+					log.Info("Error running job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "), retry)
 					jobState.errorRunningTask(taskId, err)
 				}
 
 				// update cluster state that this node is now free
 				s.clusterState.taskCompleted(nodeId, taskId)
-				log.Println("Freeing node:", nodeId, ", removed job:", jobId, ", task:", taskId)
+				log.Info("Freeing node:", nodeId, ", removed job:", jobId, ", task:", taskId)
 			})
 	}
 }

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"strings"
 	"time"
 

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -242,7 +242,7 @@ func (s *statefulScheduler) checkForCompletedJobs() {
 				},
 				func(err error) {
 					if err == nil {
-						log.Debug("Job %v Completed \n", j.Job.Id)
+						log.Info("Job %v Completed \n", j.Job.Id)
 						// This job is fully processed remove from
 						// InProgressJobs
 						delete(s.inProgressJobs, j.Job.Id)
@@ -285,7 +285,7 @@ func (s *statefulScheduler) scheduleTasks() {
 
 		// Mark Task as Started
 		s.clusterState.taskScheduled(nodeId, taskId, taskDef.SnapshotID)
-		log.Debug("job:%s, task:%s, scheduled on node:%s\n", jobId, taskId, nodeId)
+		log.Info("job:%s, task:%s, scheduled on node:%s\n", jobId, taskId, nodeId)
 		jobState.taskStarted(taskId)
 
 		runner := &taskRunner{
@@ -307,7 +307,7 @@ func (s *statefulScheduler) scheduleTasks() {
 			func(err error) {
 				// update the jobState
 				if err == nil {
-					log.Debug("Ending job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "))
+					log.Info("Ending job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "))
 
 					jobState.taskCompleted(taskId)
 				} else {
@@ -315,13 +315,13 @@ func (s *statefulScheduler) scheduleTasks() {
 					if preventRetries {
 						retry = "(will not be retried)"
 					}
-					log.Debug("Error running job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "), retry)
+					log.Info("Error running job:", jobId, ", task:", taskId, " command:", strings.Join(taskDef.Argv, " "), retry)
 					jobState.errorRunningTask(taskId, err)
 				}
 
 				// update cluster state that this node is now free
 				s.clusterState.taskCompleted(nodeId, taskId)
-				log.Debug("Freeing node:", nodeId, ", removed job:", jobId, ", task:", taskId)
+				log.Info("Freeing node:", nodeId, ", removed job:", jobId, ", task:", taskId)
 			})
 	}
 }

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"strings"
 	"time"
 

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -154,7 +154,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedStarts(t
 	}
 
 	taskId := taskIds[0]
-	log.Debug("watching", taskId)
+	log.Info("watching", taskId)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -198,7 +198,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 	}
 
 	taskId := taskIds[0]
-	log.Debug("watching", taskId)
+	log.Info("watching", taskId)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -3,7 +3,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"testing"
 	"time"
 

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -154,7 +154,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedStarts(t
 	}
 
 	taskId := taskIds[0]
-	log.Info("watching", taskId)
+	log.Debug("watching", taskId)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -198,7 +198,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 	}
 
 	taskId := taskIds[0]
-	log.Info("watching", taskId)
+	log.Debug("watching", taskId)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -3,7 +3,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"testing"
 	"time"
 
@@ -154,7 +154,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedStarts(t
 	}
 
 	taskId := taskIds[0]
-	log.Println("watching", taskId)
+	log.Info("watching", taskId)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -198,7 +198,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 	}
 
 	taskId := taskIds[0]
-	log.Println("watching", taskId)
+	log.Info("watching", taskId)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -3,7 +3,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"testing"
 	"time"
 

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"strings"
 	"time"
 

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"strings"
 	"time"
 
@@ -34,7 +34,7 @@ type taskRunner struct {
 // are logged and the task completes
 // parameters:
 func (r *taskRunner) run() error {
-	log.Println("Starting task - job:", r.jobId, " task:", r.taskId, " command:", strings.Join(r.task.Argv, " "))
+	log.Info("Starting task - job:", r.jobId, " task:", r.taskId, " command:", strings.Join(r.task.Argv, " "))
 	// Log StartTask Message to SagaLog
 	if err := r.logTaskStatus(nil, saga.StartTask); err != nil {
 		return err
@@ -52,14 +52,14 @@ func (r *taskRunner) run() error {
 		}
 	}
 
-	log.Printf("End task - job:%s, task:%s, runStatus:%s\n", r.jobId, r.taskId, st.String())
+	log.Info("End task - job:%s, task:%s, runStatus:%s\n", r.jobId, r.taskId, st.String())
 
 	shouldLog := (err == nil)
 
 	if err != nil && r.markCompleteOnFailure {
 		st.Error = err.Error()
 		st.ExitCode = DeadLetterExitCode
-		log.Printf(
+		log.Info(
 			`Error Running Task %v: dead lettering task after max retries.
 				TaskDef: %+v, Saga Id: %v, Error: %v`,
 			r.taskId, r.task, r.saga.GetState().SagaId(), err)

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -34,7 +34,7 @@ type taskRunner struct {
 // are logged and the task completes
 // parameters:
 func (r *taskRunner) run() error {
-	log.Debug("Starting task - job:", r.jobId, " task:", r.taskId, " command:", strings.Join(r.task.Argv, " "))
+	log.Info("Starting task - job:", r.jobId, " task:", r.taskId, " command:", strings.Join(r.task.Argv, " "))
 	// Log StartTask Message to SagaLog
 	if err := r.logTaskStatus(nil, saga.StartTask); err != nil {
 		return err
@@ -52,14 +52,14 @@ func (r *taskRunner) run() error {
 		}
 	}
 
-	log.Debug("End task - job:%s, task:%s, runStatus:%s\n", r.jobId, r.taskId, st.String())
+	log.Info("End task - job:%s, task:%s, runStatus:%s\n", r.jobId, r.taskId, st.String())
 
 	shouldLog := (err == nil)
 
 	if err != nil && r.markCompleteOnFailure {
 		st.Error = err.Error()
 		st.ExitCode = DeadLetterExitCode
-		log.Debug(
+		log.Info(
 			`Error Running Task %v: dead lettering task after max retries.
 				TaskDef: %+v, Saga Id: %v, Error: %v`,
 			r.taskId, r.task, r.saga.GetState().SagaId(), err)

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"strings"
 	"time"
 

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -34,7 +34,7 @@ type taskRunner struct {
 // are logged and the task completes
 // parameters:
 func (r *taskRunner) run() error {
-	log.Info("Starting task - job:", r.jobId, " task:", r.taskId, " command:", strings.Join(r.task.Argv, " "))
+	log.Debug("Starting task - job:", r.jobId, " task:", r.taskId, " command:", strings.Join(r.task.Argv, " "))
 	// Log StartTask Message to SagaLog
 	if err := r.logTaskStatus(nil, saga.StartTask); err != nil {
 		return err
@@ -52,14 +52,14 @@ func (r *taskRunner) run() error {
 		}
 	}
 
-	log.Info("End task - job:%s, task:%s, runStatus:%s\n", r.jobId, r.taskId, st.String())
+	log.Debug("End task - job:%s, task:%s, runStatus:%s\n", r.jobId, r.taskId, st.String())
 
 	shouldLog := (err == nil)
 
 	if err != nil && r.markCompleteOnFailure {
 		st.Error = err.Error()
 		st.ExitCode = DeadLetterExitCode
-		log.Info(
+		log.Debug(
 			`Error Running Task %v: dead lettering task after max retries.
 				TaskDef: %+v, Saga Id: %v, Error: %v`,
 			r.taskId, r.task, r.saga.GetState().SagaId(), err)

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/scootdev/scoot/cloud/cluster"
 )

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/scootdev/scoot/cloud/cluster"
 )

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -41,9 +41,9 @@ func getTaskAssignments(cs *clusterState, tasks []*taskState) ([]taskAssignment,
 	remainingTasks := getAssignments(cs, tasks, &assignments, nodeGroups, []string{""})
 	remainingTasks = getAssignments(cs, remainingTasks, &assignments, nodeGroups, snapshotIds)
 	if len(remainingTasks) == 0 {
-		log.Debug("Scheduled all tasks (%d)", len(tasks))
+		log.Info("Scheduled all tasks (%d)", len(tasks))
 	} else {
-		log.Debug("Unable to schedule all tasks, remaining=%d/%d", len(remainingTasks), len(tasks))
+		log.Info("Unable to schedule all tasks, remaining=%d/%d", len(remainingTasks), len(tasks))
 	}
 	return assignments, nodeGroups
 }
@@ -71,7 +71,7 @@ Loop:
 					}
 					nodeGroups[task.Def.SnapshotID].busy[nodeId] = node
 					delete(nodeGroups[snapId].idle, nodeId)
-					log.Debug("Scheduled jobId=%s, taskId=%s, node=%s, progress=%d/%d",
+					log.Info("Scheduled jobId=%s, taskId=%s, node=%s, progress=%d/%d",
 						task.JobId, task.TaskId, nodeId, len(*assignments), numTotalTasks)
 					continue Loop
 				}

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -41,9 +41,9 @@ func getTaskAssignments(cs *clusterState, tasks []*taskState) ([]taskAssignment,
 	remainingTasks := getAssignments(cs, tasks, &assignments, nodeGroups, []string{""})
 	remainingTasks = getAssignments(cs, remainingTasks, &assignments, nodeGroups, snapshotIds)
 	if len(remainingTasks) == 0 {
-		log.Info("Scheduled all tasks (%d)", len(tasks))
+		log.Debug("Scheduled all tasks (%d)", len(tasks))
 	} else {
-		log.Info("Unable to schedule all tasks, remaining=%d/%d", len(remainingTasks), len(tasks))
+		log.Debug("Unable to schedule all tasks, remaining=%d/%d", len(remainingTasks), len(tasks))
 	}
 	return assignments, nodeGroups
 }
@@ -71,7 +71,7 @@ Loop:
 					}
 					nodeGroups[task.Def.SnapshotID].busy[nodeId] = node
 					delete(nodeGroups[snapId].idle, nodeId)
-					log.Info("Scheduled jobId=%s, taskId=%s, node=%s, progress=%d/%d",
+					log.Debug("Scheduled jobId=%s, taskId=%s, node=%s, progress=%d/%d",
 						task.JobId, task.TaskId, nodeId, len(*assignments), numTotalTasks)
 					continue Loop
 				}

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -1,7 +1,7 @@
 package scheduler
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/scootdev/scoot/cloud/cluster"
 )
@@ -41,9 +41,9 @@ func getTaskAssignments(cs *clusterState, tasks []*taskState) ([]taskAssignment,
 	remainingTasks := getAssignments(cs, tasks, &assignments, nodeGroups, []string{""})
 	remainingTasks = getAssignments(cs, remainingTasks, &assignments, nodeGroups, snapshotIds)
 	if len(remainingTasks) == 0 {
-		log.Printf("Scheduled all tasks (%d)", len(tasks))
+		log.Info("Scheduled all tasks (%d)", len(tasks))
 	} else {
-		log.Printf("Unable to schedule all tasks, remaining=%d/%d", len(remainingTasks), len(tasks))
+		log.Info("Unable to schedule all tasks, remaining=%d/%d", len(remainingTasks), len(tasks))
 	}
 	return assignments, nodeGroups
 }
@@ -71,7 +71,7 @@ Loop:
 					}
 					nodeGroups[task.Def.SnapshotID].busy[nodeId] = node
 					delete(nodeGroups[snapId].idle, nodeId)
-					log.Printf("Scheduled jobId=%s, taskId=%s, node=%s, progress=%d/%d",
+					log.Info("Scheduled jobId=%s, taskId=%s, node=%s, progress=%d/%d",
 						task.JobId, task.TaskId, nodeId, len(*assignments), numTotalTasks)
 					continue Loop
 				}

--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 type getStatusCmd struct {
@@ -24,7 +24,7 @@ func (c *getStatusCmd) registerFlags() *cobra.Command {
 
 func (c *getStatusCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
 
-	log.Println("Checking Status for Scoot Job", args)
+	log.Info("Checking Status for Scoot Job", args)
 
 	if len(args) == 0 {
 		return errors.New("a job id must be provided")

--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"github.com/spf13/cobra"
 )

--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"github.com/spf13/cobra"
 )

--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -24,7 +24,7 @@ func (c *getStatusCmd) registerFlags() *cobra.Command {
 
 func (c *getStatusCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
 
-	log.Info("Checking Status for Scoot Job", args)
+	log.Debug("Checking Status for Scoot Job", args)
 
 	if len(args) == 0 {
 		return errors.New("a job id must be provided")

--- a/scootapi/client/get_status_cmd.go
+++ b/scootapi/client/get_status_cmd.go
@@ -24,7 +24,7 @@ func (c *getStatusCmd) registerFlags() *cobra.Command {
 
 func (c *getStatusCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
 
-	log.Debug("Checking Status for Scoot Job", args)
+	log.Info("Checking Status for Scoot Job", args)
 
 	if len(args) == 0 {
 		return errors.New("a job id must be provided")

--- a/scootapi/client/run_job_cmd.go
+++ b/scootapi/client/run_job_cmd.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io/ioutil"
 	"os"
 

--- a/scootapi/client/run_job_cmd.go
+++ b/scootapi/client/run_job_cmd.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io/ioutil"
 	"os"
 

--- a/scootapi/client/run_job_cmd.go
+++ b/scootapi/client/run_job_cmd.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/inconshreveable/log15"
 	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
@@ -41,7 +41,7 @@ type TaskDef struct {
 }
 
 func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
-	log.Println("Running on scoot", args)
+	log.Info("Running on scoot", args)
 
 	jobDef := scoot.NewJobDefinition()
 	switch {
@@ -49,11 +49,11 @@ func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) 
 		return errors.New("You must provide either args or a job definition")
 	case len(args) > 0:
 		if c.snapshotId == "" {
-			log.Println("No snapshotID provided - cmd will be run in an empty tmpdir.")
+			log.Info("No snapshotID provided - cmd will be run in an empty tmpdir.")
 		} else if !strings.Contains(c.snapshotId, "-") {
 			//this is not a bundleID, assume it's a sha that's available upstream. Cf. snapshot/git/gitdb/README.md
 			streamId := fmt.Sprintf("stream-swh-%s-%s", c.streamName, c.snapshotId)
-			log.Printf("Converting sha to a stream-based snapshot_id: %s -> %s", c.snapshotId, streamId)
+			log.Info("Converting sha to a stream-based snapshot_id: %s -> %s", c.snapshotId, streamId)
 			c.snapshotId = streamId
 		}
 		task := scoot.NewTaskDefinition()
@@ -99,7 +99,7 @@ func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) 
 	}
 
 	fmt.Println(jobId.ID)
-	log.Printf("JobID:%s\n", jobId.ID)
+	log.Info("JobID:%s\n", jobId.ID)
 
 	return nil
 }

--- a/scootapi/client/run_job_cmd.go
+++ b/scootapi/client/run_job_cmd.go
@@ -41,7 +41,7 @@ type TaskDef struct {
 }
 
 func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
-	log.Info("Running on scoot", args)
+	log.Debug("Running on scoot", args)
 
 	jobDef := scoot.NewJobDefinition()
 	switch {
@@ -49,11 +49,11 @@ func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) 
 		return errors.New("You must provide either args or a job definition")
 	case len(args) > 0:
 		if c.snapshotId == "" {
-			log.Info("No snapshotID provided - cmd will be run in an empty tmpdir.")
+			log.Debug("No snapshotID provided - cmd will be run in an empty tmpdir.")
 		} else if !strings.Contains(c.snapshotId, "-") {
 			//this is not a bundleID, assume it's a sha that's available upstream. Cf. snapshot/git/gitdb/README.md
 			streamId := fmt.Sprintf("stream-swh-%s-%s", c.streamName, c.snapshotId)
-			log.Info("Converting sha to a stream-based snapshot_id: %s -> %s", c.snapshotId, streamId)
+			log.Debug("Converting sha to a stream-based snapshot_id: %s -> %s", c.snapshotId, streamId)
 			c.snapshotId = streamId
 		}
 		task := scoot.NewTaskDefinition()
@@ -99,7 +99,7 @@ func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) 
 	}
 
 	fmt.Println(jobId.ID)
-	log.Info("JobID:%s\n", jobId.ID)
+	log.Debug("JobID:%s\n", jobId.ID)
 
 	return nil
 }

--- a/scootapi/client/run_job_cmd.go
+++ b/scootapi/client/run_job_cmd.go
@@ -41,7 +41,7 @@ type TaskDef struct {
 }
 
 func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
-	log.Debug("Running on scoot", args)
+	log.Info("Running on scoot", args)
 
 	jobDef := scoot.NewJobDefinition()
 	switch {
@@ -49,11 +49,11 @@ func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) 
 		return errors.New("You must provide either args or a job definition")
 	case len(args) > 0:
 		if c.snapshotId == "" {
-			log.Debug("No snapshotID provided - cmd will be run in an empty tmpdir.")
+			log.Info("No snapshotID provided - cmd will be run in an empty tmpdir.")
 		} else if !strings.Contains(c.snapshotId, "-") {
 			//this is not a bundleID, assume it's a sha that's available upstream. Cf. snapshot/git/gitdb/README.md
 			streamId := fmt.Sprintf("stream-swh-%s-%s", c.streamName, c.snapshotId)
-			log.Debug("Converting sha to a stream-based snapshot_id: %s -> %s", c.snapshotId, streamId)
+			log.Info("Converting sha to a stream-based snapshot_id: %s -> %s", c.snapshotId, streamId)
 			c.snapshotId = streamId
 		}
 		task := scoot.NewTaskDefinition()
@@ -99,7 +99,7 @@ func (c *runJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) 
 	}
 
 	fmt.Println(jobId.ID)
-	log.Debug("JobID:%s\n", jobId.ID)
+	log.Info("JobID:%s\n", jobId.ID)
 
 	return nil
 }

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -40,8 +40,8 @@ func (c *smokeTestCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []strin
 	if err != nil {
 		return err
 	}
-	log.Debug("Starting Smoke Test")
-	log.Debug("** Note ** Inmemory workers not supported at time since everything they do is a nop.")
+	log.Info("Starting Smoke Test")
+	log.Info("** Note ** Inmemory workers not supported at time since everything they do is a nop.")
 	runner := &smokeTestRunner{cl: cl, tmp: tmp}
 	if err := runner.run(c.numJobs, c.numTasks, c.timeout); err != nil {
 		panic(err) // returning err would make cobra print out usage, which doesn't make sense to do here.

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/inconshreveable/log15"
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"github.com/scootdev/scoot/tests/testhelpers"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 type smokeTestCmd struct {
@@ -40,8 +40,8 @@ func (c *smokeTestCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []strin
 	if err != nil {
 		return err
 	}
-	log.Println("Starting Smoke Test")
-	log.Println("** Note ** Inmemory workers not supported at time since everything they do is a nop.")
+	log.Info("Starting Smoke Test")
+	log.Info("** Note ** Inmemory workers not supported at time since everything they do is a nop.")
 	runner := &smokeTestRunner{cl: cl, tmp: tmp}
 	if err := runner.run(c.numJobs, c.numTasks, c.timeout); err != nil {
 		panic(err) // returning err would make cobra print out usage, which doesn't make sense to do here.

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"github.com/scootdev/scoot/tests/testhelpers"

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -40,8 +40,8 @@ func (c *smokeTestCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []strin
 	if err != nil {
 		return err
 	}
-	log.Info("Starting Smoke Test")
-	log.Info("** Note ** Inmemory workers not supported at time since everything they do is a nop.")
+	log.Debug("Starting Smoke Test")
+	log.Debug("** Note ** Inmemory workers not supported at time since everything they do is a nop.")
 	runner := &smokeTestRunner{cl: cl, tmp: tmp}
 	if err := runner.run(c.numJobs, c.numTasks, c.timeout); err != nil {
 		panic(err) // returning err would make cobra print out usage, which doesn't make sense to do here.

--- a/scootapi/client/smoke_test_cmd.go
+++ b/scootapi/client/smoke_test_cmd.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi/gen-go/scoot"
 	"github.com/scootdev/scoot/tests/testhelpers"

--- a/scootapi/client/watch_job_cmd.go
+++ b/scootapi/client/watch_job_cmd.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,7 +29,7 @@ func (c *watchJobCmd) registerFlags() *cobra.Command {
 
 func (c *watchJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
 
-	log.Println("Watching job:", args)
+	log.Info("Watching job:", args)
 
 	if args == nil || len(args) == 0 {
 		return errors.New("a job id must be provided")

--- a/scootapi/client/watch_job_cmd.go
+++ b/scootapi/client/watch_job_cmd.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"time"
 
 	"github.com/pkg/errors"

--- a/scootapi/client/watch_job_cmd.go
+++ b/scootapi/client/watch_job_cmd.go
@@ -29,7 +29,7 @@ func (c *watchJobCmd) registerFlags() *cobra.Command {
 
 func (c *watchJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
 
-	log.Info("Watching job:", args)
+	log.Debug("Watching job:", args)
 
 	if args == nil || len(args) == 0 {
 		return errors.New("a job id must be provided")

--- a/scootapi/client/watch_job_cmd.go
+++ b/scootapi/client/watch_job_cmd.go
@@ -29,7 +29,7 @@ func (c *watchJobCmd) registerFlags() *cobra.Command {
 
 func (c *watchJobCmd) run(cl *simpleCLIClient, cmd *cobra.Command, args []string) error {
 
-	log.Debug("Watching job:", args)
+	log.Info("Watching job:", args)
 
 	if args == nil || len(args) == 0 {
 		return errors.New("a job id must be provided")

--- a/scootapi/client/watch_job_cmd.go
+++ b/scootapi/client/watch_job_cmd.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"time"
 
 	"github.com/pkg/errors"

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -121,7 +121,7 @@ func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	// Parse Config
-	log.Debug("scootapi/server RunServer(), config is:", string(config))
+	log.Info("scootapi/server RunServer(), config is:", string(config))
 	mod, err := schema.Parse(config)
 	if err != nil {
 		log.Crit("Error configuring Scoot API: ", err)

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -121,10 +121,10 @@ func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	// Parse Config
-	log.Println("scootapi/server RunServer(), config is:", string(config))
+	log.Info("scootapi/server RunServer(), config is:", string(config))
 	mod, err := schema.Parse(config)
 	if err != nil {
-		log.Fatal("Error configuring Scoot API: ", err)
+		log.Crit("Error configuring Scoot API: ", err)
 	}
 
 	// Initialize Objects Based on Config Settings
@@ -134,7 +134,7 @@ func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	var servers servers
 	err = bag.Extract(&servers)
 	if err != nil {
-		log.Fatal("Error injecting servers", err)
+		log.Crit("Error injecting servers", err)
 	}
 
 	errCh := make(chan error)
@@ -144,5 +144,5 @@ func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	go func() {
 		errCh <- servers.thrift.Serve()
 	}()
-	log.Fatal("Error serving: ", <-errCh)
+	log.Crit("Error serving: ", <-errCh)
 }

--- a/scootapi/server/setup.go
+++ b/scootapi/server/setup.go
@@ -121,7 +121,7 @@ func Defaults() (*ice.MagicBag, jsonconfig.Schema) {
 // this method blocks until the server completes running or an error occurs.
 func RunServer(bag *ice.MagicBag, schema jsonconfig.Schema, config []byte) {
 	// Parse Config
-	log.Info("scootapi/server RunServer(), config is:", string(config))
+	log.Debug("scootapi/server RunServer(), config is:", string(config))
 	mod, err := schema.Parse(config)
 	if err != nil {
 		log.Crit("Error configuring Scoot API: ", err)

--- a/scootapi/setup/api.go
+++ b/scootapi/setup/api.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 
 	"github.com/scootdev/scoot/os/temp"

--- a/scootapi/setup/api.go
+++ b/scootapi/setup/api.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 
 	"github.com/scootdev/scoot/os/temp"
@@ -41,7 +41,7 @@ func NewLocalApiStrategy(apiCfg *ApiConfig, builder Builder, cmds *Cmds) *LocalA
 }
 
 func (s *LocalApiStrategy) Startup() ([]string, error) {
-	log.Println("Starting up a Local ApiServer")
+	log.Info("Starting up a Local ApiServer")
 	if s.apiCfg.Count < 0 {
 		return nil, fmt.Errorf("ApiServer count must be >0 (or zero for default #), was: %d", s.apiCfg.Count)
 	} else if s.apiCfg.Count == 0 {

--- a/scootapi/setup/api.go
+++ b/scootapi/setup/api.go
@@ -41,7 +41,7 @@ func NewLocalApiStrategy(apiCfg *ApiConfig, builder Builder, cmds *Cmds) *LocalA
 }
 
 func (s *LocalApiStrategy) Startup() ([]string, error) {
-	log.Debug("Starting up a Local ApiServer")
+	log.Info("Starting up a Local ApiServer")
 	if s.apiCfg.Count < 0 {
 		return nil, fmt.Errorf("ApiServer count must be >0 (or zero for default #), was: %d", s.apiCfg.Count)
 	} else if s.apiCfg.Count == 0 {

--- a/scootapi/setup/api.go
+++ b/scootapi/setup/api.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 
 	"github.com/scootdev/scoot/os/temp"

--- a/scootapi/setup/api.go
+++ b/scootapi/setup/api.go
@@ -41,7 +41,7 @@ func NewLocalApiStrategy(apiCfg *ApiConfig, builder Builder, cmds *Cmds) *LocalA
 }
 
 func (s *LocalApiStrategy) Startup() ([]string, error) {
-	log.Info("Starting up a Local ApiServer")
+	log.Debug("Starting up a Local ApiServer")
 	if s.apiCfg.Count < 0 {
 		return nil, fmt.Errorf("ApiServer count must be >0 (or zero for default #), was: %d", s.apiCfg.Count)
 	} else if s.apiCfg.Count == 0 {

--- a/scootapi/setup/cmds.go
+++ b/scootapi/setup/cmds.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -49,7 +49,7 @@ func NewSignalHandlingCmds(tmp *temp.TempDir) *Cmds {
 	go func() {
 		var sig os.Signal
 		sig = <-sigchan
-		log.Printf("signal %s received; shutting down", sig)
+		log.Info("signal %s received; shutting down", sig)
 		r.Kill()
 		os.Exit(1)
 	}()
@@ -71,7 +71,7 @@ func (c *Cmds) Kill() {
 	}
 	c.killed = true
 
-	log.Printf("Killing %d cmds", len(c.watching))
+	log.Info("Killing %d cmds", len(c.watching))
 
 	// Wait for all to be done.
 	allDoneCh := make(chan struct{})
@@ -87,7 +87,7 @@ func (c *Cmds) Kill() {
 	// First, send SIGINT to each
 	for _, c := range c.watching {
 		if p := c.Process; p != nil {
-			log.Printf("SIGINT: %d %v", p.Pid, c.Path)
+			log.Info("SIGINT: %d %v", p.Pid, c.Path)
 			syscall.Kill(-1*p.Pid, syscall.SIGINT)
 		}
 	}
@@ -96,9 +96,9 @@ func (c *Cmds) Kill() {
 	c.mu.Unlock()
 	select {
 	case <-allDoneCh:
-		log.Printf("All completed")
+		log.Info("All completed")
 	case <-time.After(5 * time.Second):
-		log.Printf("Still waiting; killing all")
+		log.Info("Still waiting; killing all")
 	}
 	c.mu.Lock()
 
@@ -109,7 +109,7 @@ func (c *Cmds) Kill() {
 	// They've been warned; now send SIGKILL
 	for _, c := range c.watching {
 		if p := c.Process; p != nil {
-			log.Printf("SIGKILL: %d %v", p.Pid, c.Path)
+			log.Info("SIGKILL: %d %v", p.Pid, c.Path)
 			syscall.Kill(-1*p.Pid, syscall.SIGKILL)
 		}
 	}
@@ -137,14 +137,14 @@ func (c *Cmds) StartCmd(cmd *exec.Cmd) error {
 	if c.killed {
 		return fmt.Errorf("killed; cannot start new cmds")
 	}
-	log.Println("Starting", cmd.Args)
+	log.Info("Starting", cmd.Args)
 	err := cmd.Start()
 	if err == nil {
 		go func() {
 			pid := cmd.Process.Pid
-			log.Printf("Cmd %v started as %v", cmd.Args, pid)
+			log.Info("Cmd %v started as %v", cmd.Args, pid)
 			cmd.Wait()
-			log.Printf("Cmd %v (%v) finished", pid, cmd.Path)
+			log.Info("Cmd %v (%v) finished", pid, cmd.Path)
 			c.remove(cmd)
 			c.Kill()
 		}()
@@ -154,11 +154,11 @@ func (c *Cmds) StartCmd(cmd *exec.Cmd) error {
 
 // RunCmd runs a Cmd that was created by Command
 func (c *Cmds) RunCmd(cmd *exec.Cmd) error {
-	log.Println("Running", cmd.Args)
+	log.Info("Running", cmd.Args)
 	// remove cmd once it's done
 	defer c.remove(cmd)
 	err := cmd.Run()
-	log.Println("Run Done: ", err)
+	log.Info("Run Done: ", err)
 	return err
 }
 

--- a/scootapi/setup/cmds.go
+++ b/scootapi/setup/cmds.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"os/exec"
 	"os/signal"

--- a/scootapi/setup/cmds.go
+++ b/scootapi/setup/cmds.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"os/exec"
 	"os/signal"

--- a/scootapi/setup/ports.go
+++ b/scootapi/setup/ports.go
@@ -17,14 +17,14 @@ func WaitForPort(port int) error {
 // WaitForPortTimeout waits timeout for a process to listen to the port, and returns an error if
 // the port remains open
 func WaitForPortTimeout(port int, timeout time.Duration) error {
-	log.Debug("Waiting for port %v for %v", port, timeout)
+	log.Info("Waiting for port %v for %v", port, timeout)
 	end := time.Now().Add(timeout)
 	for !time.Now().After(end) {
 		// Use exec.Command because we don't worry about these getting orphaned,
 		// and don't want to fill up our Cmds's list of running cmds
 		cmd := exec.Command("nc", "-z", "localhost", strconv.Itoa(port))
 		if err := cmd.Run(); err == nil {
-			log.Debug("Port %v active", port)
+			log.Info("Port %v active", port)
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/scootapi/setup/ports.go
+++ b/scootapi/setup/ports.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os/exec"
 	"strconv"
 	"time"

--- a/scootapi/setup/ports.go
+++ b/scootapi/setup/ports.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os/exec"
 	"strconv"
 	"time"
@@ -17,14 +17,14 @@ func WaitForPort(port int) error {
 // WaitForPortTimeout waits timeout for a process to listen to the port, and returns an error if
 // the port remains open
 func WaitForPortTimeout(port int, timeout time.Duration) error {
-	log.Printf("Waiting for port %v for %v", port, timeout)
+	log.Info("Waiting for port %v for %v", port, timeout)
 	end := time.Now().Add(timeout)
 	for !time.Now().After(end) {
 		// Use exec.Command because we don't worry about these getting orphaned,
 		// and don't want to fill up our Cmds's list of running cmds
 		cmd := exec.Command("nc", "-z", "localhost", strconv.Itoa(port))
 		if err := cmd.Run(); err == nil {
-			log.Printf("Port %v active", port)
+			log.Info("Port %v active", port)
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/scootapi/setup/ports.go
+++ b/scootapi/setup/ports.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os/exec"
 	"strconv"
 	"time"

--- a/scootapi/setup/ports.go
+++ b/scootapi/setup/ports.go
@@ -17,14 +17,14 @@ func WaitForPort(port int) error {
 // WaitForPortTimeout waits timeout for a process to listen to the port, and returns an error if
 // the port remains open
 func WaitForPortTimeout(port int, timeout time.Duration) error {
-	log.Info("Waiting for port %v for %v", port, timeout)
+	log.Debug("Waiting for port %v for %v", port, timeout)
 	end := time.Now().Add(timeout)
 	for !time.Now().After(end) {
 		// Use exec.Command because we don't worry about these getting orphaned,
 		// and don't want to fill up our Cmds's list of running cmds
 		cmd := exec.Command("nc", "-z", "localhost", strconv.Itoa(port))
 		if err := cmd.Run(); err == nil {
-			log.Info("Port %v active", port)
+			log.Debug("Port %v active", port)
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/scootapi/setup/sched.go
+++ b/scootapi/setup/sched.go
@@ -1,7 +1,7 @@
 package setup
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"strconv"
 	"strings"
 
@@ -34,7 +34,7 @@ func NewLocalSchedStrategy(workersCfg *WorkerConfig, workers WorkersStrategy, bu
 }
 
 func (s *LocalSchedStrategy) Startup() (string, error) {
-	log.Println("Starting up a Local Scheduler")
+	log.Info("Starting up a Local Scheduler")
 
 	config, err := s.workers.StartupWorkers()
 	if err != nil {

--- a/scootapi/setup/sched.go
+++ b/scootapi/setup/sched.go
@@ -1,7 +1,7 @@
 package setup
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"strconv"
 	"strings"
 

--- a/scootapi/setup/sched.go
+++ b/scootapi/setup/sched.go
@@ -1,7 +1,7 @@
 package setup
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"strconv"
 	"strings"
 

--- a/scootapi/setup/sched.go
+++ b/scootapi/setup/sched.go
@@ -34,7 +34,7 @@ func NewLocalSchedStrategy(workersCfg *WorkerConfig, workers WorkersStrategy, bu
 }
 
 func (s *LocalSchedStrategy) Startup() (string, error) {
-	log.Debug("Starting up a Local Scheduler")
+	log.Info("Starting up a Local Scheduler")
 
 	config, err := s.workers.StartupWorkers()
 	if err != nil {

--- a/scootapi/setup/sched.go
+++ b/scootapi/setup/sched.go
@@ -34,7 +34,7 @@ func NewLocalSchedStrategy(workersCfg *WorkerConfig, workers WorkersStrategy, bu
 }
 
 func (s *LocalSchedStrategy) Startup() (string, error) {
-	log.Info("Starting up a Local Scheduler")
+	log.Debug("Starting up a Local Scheduler")
 
 	config, err := s.workers.StartupWorkers()
 	if err != nil {

--- a/scootapi/setup/workers.go
+++ b/scootapi/setup/workers.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"strconv"
 
 	"github.com/scootdev/scoot/scootapi"
@@ -37,7 +37,7 @@ func NewInMemoryWorkers(workersCfg *WorkerConfig) *InMemoryWorkersStrategy {
 }
 
 func (s *InMemoryWorkersStrategy) StartupWorkers() (string, error) {
-	log.Println("Using in-memory workers")
+	log.Info("Using in-memory workers")
 	if s.workersCfg.Count == 0 {
 		return "local.memory", nil
 	}
@@ -67,14 +67,14 @@ func NewLocalWorkers(workersCfg *WorkerConfig, builder Builder, cmds *Cmds) *Loc
 }
 
 func (s *LocalWorkersStrategy) StartupWorkers() (string, error) {
-	log.Printf("Using local workers")
+	log.Info("Using local workers")
 	if s.workersCfg.Count < 0 {
 		return "", fmt.Errorf("LocalWorkers must start with at least 1 worker (or zero for default #): %v", s.workersCfg.Count)
 	} else if s.workersCfg.Count == 0 {
 		s.workersCfg.Count = DefaultWorkerCount
 	}
 
-	log.Printf("Using %d local workers", s.workersCfg.Count)
+	log.Info("Using %d local workers", s.workersCfg.Count)
 
 	bin, err := s.builder.Worker()
 	if err != nil {

--- a/scootapi/setup/workers.go
+++ b/scootapi/setup/workers.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"strconv"
 
 	"github.com/scootdev/scoot/scootapi"

--- a/scootapi/setup/workers.go
+++ b/scootapi/setup/workers.go
@@ -37,7 +37,7 @@ func NewInMemoryWorkers(workersCfg *WorkerConfig) *InMemoryWorkersStrategy {
 }
 
 func (s *InMemoryWorkersStrategy) StartupWorkers() (string, error) {
-	log.Debug("Using in-memory workers")
+	log.Info("Using in-memory workers")
 	if s.workersCfg.Count == 0 {
 		return "local.memory", nil
 	}
@@ -67,14 +67,14 @@ func NewLocalWorkers(workersCfg *WorkerConfig, builder Builder, cmds *Cmds) *Loc
 }
 
 func (s *LocalWorkersStrategy) StartupWorkers() (string, error) {
-	log.Debug("Using local workers")
+	log.Info("Using local workers")
 	if s.workersCfg.Count < 0 {
 		return "", fmt.Errorf("LocalWorkers must start with at least 1 worker (or zero for default #): %v", s.workersCfg.Count)
 	} else if s.workersCfg.Count == 0 {
 		s.workersCfg.Count = DefaultWorkerCount
 	}
 
-	log.Debug("Using %d local workers", s.workersCfg.Count)
+	log.Info("Using %d local workers", s.workersCfg.Count)
 
 	bin, err := s.builder.Worker()
 	if err != nil {

--- a/scootapi/setup/workers.go
+++ b/scootapi/setup/workers.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"strconv"
 
 	"github.com/scootdev/scoot/scootapi"

--- a/scootapi/setup/workers.go
+++ b/scootapi/setup/workers.go
@@ -37,7 +37,7 @@ func NewInMemoryWorkers(workersCfg *WorkerConfig) *InMemoryWorkersStrategy {
 }
 
 func (s *InMemoryWorkersStrategy) StartupWorkers() (string, error) {
-	log.Info("Using in-memory workers")
+	log.Debug("Using in-memory workers")
 	if s.workersCfg.Count == 0 {
 		return "local.memory", nil
 	}
@@ -67,14 +67,14 @@ func NewLocalWorkers(workersCfg *WorkerConfig, builder Builder, cmds *Cmds) *Loc
 }
 
 func (s *LocalWorkersStrategy) StartupWorkers() (string, error) {
-	log.Info("Using local workers")
+	log.Debug("Using local workers")
 	if s.workersCfg.Count < 0 {
 		return "", fmt.Errorf("LocalWorkers must start with at least 1 worker (or zero for default #): %v", s.workersCfg.Count)
 	} else if s.workersCfg.Count == 0 {
 		s.workersCfg.Count = DefaultWorkerCount
 	}
 
-	log.Info("Using %d local workers", s.workersCfg.Count)
+	log.Debug("Using %d local workers", s.workersCfg.Count)
 
 	bin, err := s.builder.Worker()
 	if err != nil {

--- a/snapshot/bundlestore/file_store.go
+++ b/snapshot/bundlestore/file_store.go
@@ -2,8 +2,8 @@ package bundlestore
 
 import (
 	"errors"
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +52,7 @@ func (s *FileStore) Write(name string, data io.Reader) error {
 		return errors.New("'/' not allowed in name unless reading bundle contents.")
 	}
 	bundlePath := filepath.Join(s.bundleDir, name)
-	log.Printf("Writing %s to %s", name, bundlePath)
+	log.Info("Writing %s to %s", name, bundlePath)
 	f, err := os.Create(bundlePath)
 	if err != nil {
 		return err

--- a/snapshot/bundlestore/file_store.go
+++ b/snapshot/bundlestore/file_store.go
@@ -52,7 +52,7 @@ func (s *FileStore) Write(name string, data io.Reader) error {
 		return errors.New("'/' not allowed in name unless reading bundle contents.")
 	}
 	bundlePath := filepath.Join(s.bundleDir, name)
-	log.Debug("Writing %s to %s", name, bundlePath)
+	log.Info("Writing %s to %s", name, bundlePath)
 	f, err := os.Create(bundlePath)
 	if err != nil {
 		return err

--- a/snapshot/bundlestore/file_store.go
+++ b/snapshot/bundlestore/file_store.go
@@ -52,7 +52,7 @@ func (s *FileStore) Write(name string, data io.Reader) error {
 		return errors.New("'/' not allowed in name unless reading bundle contents.")
 	}
 	bundlePath := filepath.Join(s.bundleDir, name)
-	log.Info("Writing %s to %s", name, bundlePath)
+	log.Debug("Writing %s to %s", name, bundlePath)
 	f, err := os.Create(bundlePath)
 	if err != nil {
 		return err

--- a/snapshot/bundlestore/file_store.go
+++ b/snapshot/bundlestore/file_store.go
@@ -2,7 +2,7 @@ package bundlestore
 
 import (
 	"errors"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"os"
 	"path/filepath"

--- a/snapshot/bundlestore/file_store.go
+++ b/snapshot/bundlestore/file_store.go
@@ -2,7 +2,7 @@ package bundlestore
 
 import (
 	"errors"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"os"
 	"path/filepath"

--- a/snapshot/bundlestore/groupcache.go
+++ b/snapshot/bundlestore/groupcache.go
@@ -41,7 +41,7 @@ func MakeGroupcacheStore(underlying Store, cfg *GroupcacheConfig, stat stats.Sta
 	// Create the cache which knows how to retrieve the underlying bundle data.
 	var cache = groupcache.NewGroup(cfg.Name, cfg.Memory_bytes, groupcache.GetterFunc(
 		func(ctx groupcache.Context, bundleName string, dest groupcache.Sink) error {
-			log.Debug("Not cached, try to fetch bundle and populate cache: ", bundleName)
+			log.Info("Not cached, try to fetch bundle and populate cache: ", bundleName)
 			stat.Counter("readUnderlyingCounter").Inc(1)
 			reader, err := underlying.OpenForRead(bundleName)
 			if err != nil {
@@ -71,7 +71,7 @@ func toPeers(nodes []cluster.Node, stat stats.StatsReceiver) []string {
 	for _, node := range nodes {
 		peers = append(peers, "http://"+string(node.Id()))
 	}
-	log.Debug("New groupcacheStore peers: ", peers)
+	log.Info("New groupcacheStore peers: ", peers)
 	stat.Counter("peerDiscoveryCounter").Inc(1)
 	stat.Gauge("peerCountGauge").Update(int64(len(peers)))
 	return peers
@@ -123,7 +123,7 @@ type groupcacheStore struct {
 }
 
 func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
-	log.Debug("Read() checking for cached bundle: ", name)
+	log.Info("Read() checking for cached bundle: ", name)
 	defer s.stat.Latency("readLatency_ms").Time().Stop()
 	s.stat.Counter("readCounter").Inc(1)
 	var data []byte
@@ -135,7 +135,7 @@ func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
 }
 
 func (s *groupcacheStore) Exists(name string) (bool, error) {
-	log.Debug("Exists() checking for cached bundle: ", name)
+	log.Info("Exists() checking for cached bundle: ", name)
 	defer s.stat.Latency("existsLatency_ms").Time().Stop()
 	s.stat.Counter("existsCounter").Inc(1)
 	if err := s.cache.Get(nil, name, groupcache.TruncatingByteSliceSink(&[]byte{})); err != nil {
@@ -146,7 +146,7 @@ func (s *groupcacheStore) Exists(name string) (bool, error) {
 }
 
 func (s *groupcacheStore) Write(name string, data io.Reader) error {
-	log.Debug("Write() populating cache: ", name)
+	log.Info("Write() populating cache: ", name)
 	defer s.stat.Latency("writeLatency_ms").Time().Stop()
 	s.stat.Counter("writeCounter").Inc(1)
 	b, err := ioutil.ReadAll(data)

--- a/snapshot/bundlestore/groupcache.go
+++ b/snapshot/bundlestore/groupcache.go
@@ -2,7 +2,7 @@ package bundlestore
 
 import (
 	"bytes"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/snapshot/bundlestore/groupcache.go
+++ b/snapshot/bundlestore/groupcache.go
@@ -2,9 +2,9 @@ package bundlestore
 
 import (
 	"bytes"
+	log "github.com/inconshreveable/log15"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"time"
 
@@ -41,7 +41,7 @@ func MakeGroupcacheStore(underlying Store, cfg *GroupcacheConfig, stat stats.Sta
 	// Create the cache which knows how to retrieve the underlying bundle data.
 	var cache = groupcache.NewGroup(cfg.Name, cfg.Memory_bytes, groupcache.GetterFunc(
 		func(ctx groupcache.Context, bundleName string, dest groupcache.Sink) error {
-			log.Print("Not cached, try to fetch bundle and populate cache: ", bundleName)
+			log.Info("Not cached, try to fetch bundle and populate cache: ", bundleName)
 			stat.Counter("readUnderlyingCounter").Inc(1)
 			reader, err := underlying.OpenForRead(bundleName)
 			if err != nil {
@@ -71,7 +71,7 @@ func toPeers(nodes []cluster.Node, stat stats.StatsReceiver) []string {
 	for _, node := range nodes {
 		peers = append(peers, "http://"+string(node.Id()))
 	}
-	log.Print("New groupcacheStore peers: ", peers)
+	log.Info("New groupcacheStore peers: ", peers)
 	stat.Counter("peerDiscoveryCounter").Inc(1)
 	stat.Gauge("peerCountGauge").Update(int64(len(peers)))
 	return peers
@@ -123,7 +123,7 @@ type groupcacheStore struct {
 }
 
 func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
-	log.Print("Read() checking for cached bundle: ", name)
+	log.Info("Read() checking for cached bundle: ", name)
 	defer s.stat.Latency("readLatency_ms").Time().Stop()
 	s.stat.Counter("readCounter").Inc(1)
 	var data []byte
@@ -135,7 +135,7 @@ func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
 }
 
 func (s *groupcacheStore) Exists(name string) (bool, error) {
-	log.Print("Exists() checking for cached bundle: ", name)
+	log.Info("Exists() checking for cached bundle: ", name)
 	defer s.stat.Latency("existsLatency_ms").Time().Stop()
 	s.stat.Counter("existsCounter").Inc(1)
 	if err := s.cache.Get(nil, name, groupcache.TruncatingByteSliceSink(&[]byte{})); err != nil {
@@ -146,7 +146,7 @@ func (s *groupcacheStore) Exists(name string) (bool, error) {
 }
 
 func (s *groupcacheStore) Write(name string, data io.Reader) error {
-	log.Print("Write() populating cache: ", name)
+	log.Info("Write() populating cache: ", name)
 	defer s.stat.Latency("writeLatency_ms").Time().Stop()
 	s.stat.Counter("writeCounter").Inc(1)
 	b, err := ioutil.ReadAll(data)

--- a/snapshot/bundlestore/groupcache.go
+++ b/snapshot/bundlestore/groupcache.go
@@ -41,7 +41,7 @@ func MakeGroupcacheStore(underlying Store, cfg *GroupcacheConfig, stat stats.Sta
 	// Create the cache which knows how to retrieve the underlying bundle data.
 	var cache = groupcache.NewGroup(cfg.Name, cfg.Memory_bytes, groupcache.GetterFunc(
 		func(ctx groupcache.Context, bundleName string, dest groupcache.Sink) error {
-			log.Info("Not cached, try to fetch bundle and populate cache: ", bundleName)
+			log.Debug("Not cached, try to fetch bundle and populate cache: ", bundleName)
 			stat.Counter("readUnderlyingCounter").Inc(1)
 			reader, err := underlying.OpenForRead(bundleName)
 			if err != nil {
@@ -71,7 +71,7 @@ func toPeers(nodes []cluster.Node, stat stats.StatsReceiver) []string {
 	for _, node := range nodes {
 		peers = append(peers, "http://"+string(node.Id()))
 	}
-	log.Info("New groupcacheStore peers: ", peers)
+	log.Debug("New groupcacheStore peers: ", peers)
 	stat.Counter("peerDiscoveryCounter").Inc(1)
 	stat.Gauge("peerCountGauge").Update(int64(len(peers)))
 	return peers
@@ -123,7 +123,7 @@ type groupcacheStore struct {
 }
 
 func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
-	log.Info("Read() checking for cached bundle: ", name)
+	log.Debug("Read() checking for cached bundle: ", name)
 	defer s.stat.Latency("readLatency_ms").Time().Stop()
 	s.stat.Counter("readCounter").Inc(1)
 	var data []byte
@@ -135,7 +135,7 @@ func (s *groupcacheStore) OpenForRead(name string) (io.ReadCloser, error) {
 }
 
 func (s *groupcacheStore) Exists(name string) (bool, error) {
-	log.Info("Exists() checking for cached bundle: ", name)
+	log.Debug("Exists() checking for cached bundle: ", name)
 	defer s.stat.Latency("existsLatency_ms").Time().Stop()
 	s.stat.Counter("existsCounter").Inc(1)
 	if err := s.cache.Get(nil, name, groupcache.TruncatingByteSliceSink(&[]byte{})); err != nil {
@@ -146,7 +146,7 @@ func (s *groupcacheStore) Exists(name string) (bool, error) {
 }
 
 func (s *groupcacheStore) Write(name string, data io.Reader) error {
-	log.Info("Write() populating cache: ", name)
+	log.Debug("Write() populating cache: ", name)
 	defer s.stat.Latency("writeLatency_ms").Time().Stop()
 	s.stat.Counter("writeCounter").Inc(1)
 	b, err := ioutil.ReadAll(data)

--- a/snapshot/bundlestore/groupcache.go
+++ b/snapshot/bundlestore/groupcache.go
@@ -2,7 +2,7 @@ package bundlestore
 
 import (
 	"bytes"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/snapshot/bundlestore/http_store.go
+++ b/snapshot/bundlestore/http_store.go
@@ -27,13 +27,13 @@ type httpStore struct {
 
 func (s *httpStore) OpenForRead(name string) (io.ReadCloser, error) {
 	uri := s.rootURI + name
-	log.Debug("Fetching %s", uri)
+	log.Info("Fetching %s", uri)
 	resp, err := s.client.Get(uri)
 	if err != nil {
-		log.Debug("Fetched w/error: %s %v", uri, err)
+		log.Info("Fetched w/error: %s %v", uri, err)
 		return nil, err
 	}
-	log.Debug("Fetch result %s %v", uri, resp.StatusCode)
+	log.Info("Fetch result %s %v", uri, resp.StatusCode)
 
 	if resp.StatusCode == http.StatusOK {
 		return resp.Body, nil
@@ -65,7 +65,7 @@ func (s *httpStore) Write(name string, data io.Reader) error {
 		return errors.New("'/' not allowed in name when writing bundles.")
 	}
 	uri := s.rootURI + name
-	log.Debug("Posting %s", uri)
+	log.Info("Posting %s", uri)
 	resp, err := s.client.Post(uri, "text/plain", data)
 	if err == nil {
 		defer resp.Body.Close()
@@ -74,6 +74,6 @@ func (s *httpStore) Write(name string, data io.Reader) error {
 			return errors.New(resp.Status + ": " + string(data))
 		}
 	}
-	log.Debug("Posted %s, err: %v", uri, err)
+	log.Info("Posted %s, err: %v", uri, err)
 	return err
 }

--- a/snapshot/bundlestore/http_store.go
+++ b/snapshot/bundlestore/http_store.go
@@ -3,7 +3,7 @@ package bundlestore
 import (
 	"errors"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/snapshot/bundlestore/http_store.go
+++ b/snapshot/bundlestore/http_store.go
@@ -27,13 +27,13 @@ type httpStore struct {
 
 func (s *httpStore) OpenForRead(name string) (io.ReadCloser, error) {
 	uri := s.rootURI + name
-	log.Info("Fetching %s", uri)
+	log.Debug("Fetching %s", uri)
 	resp, err := s.client.Get(uri)
 	if err != nil {
-		log.Info("Fetched w/error: %s %v", uri, err)
+		log.Debug("Fetched w/error: %s %v", uri, err)
 		return nil, err
 	}
-	log.Info("Fetch result %s %v", uri, resp.StatusCode)
+	log.Debug("Fetch result %s %v", uri, resp.StatusCode)
 
 	if resp.StatusCode == http.StatusOK {
 		return resp.Body, nil
@@ -65,7 +65,7 @@ func (s *httpStore) Write(name string, data io.Reader) error {
 		return errors.New("'/' not allowed in name when writing bundles.")
 	}
 	uri := s.rootURI + name
-	log.Info("Posting %s", uri)
+	log.Debug("Posting %s", uri)
 	resp, err := s.client.Post(uri, "text/plain", data)
 	if err == nil {
 		defer resp.Body.Close()
@@ -74,6 +74,6 @@ func (s *httpStore) Write(name string, data io.Reader) error {
 			return errors.New(resp.Status + ": " + string(data))
 		}
 	}
-	log.Info("Posted %s, err: %v", uri, err)
+	log.Debug("Posted %s, err: %v", uri, err)
 	return err
 }

--- a/snapshot/bundlestore/http_store.go
+++ b/snapshot/bundlestore/http_store.go
@@ -3,7 +3,7 @@ package bundlestore
 import (
 	"errors"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/snapshot/bundlestore/http_store.go
+++ b/snapshot/bundlestore/http_store.go
@@ -3,9 +3,9 @@ package bundlestore
 import (
 	"errors"
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -27,13 +27,13 @@ type httpStore struct {
 
 func (s *httpStore) OpenForRead(name string) (io.ReadCloser, error) {
 	uri := s.rootURI + name
-	log.Printf("Fetching %s", uri)
+	log.Info("Fetching %s", uri)
 	resp, err := s.client.Get(uri)
 	if err != nil {
-		log.Printf("Fetched w/error: %s %v", uri, err)
+		log.Info("Fetched w/error: %s %v", uri, err)
 		return nil, err
 	}
-	log.Printf("Fetch result %s %v", uri, resp.StatusCode)
+	log.Info("Fetch result %s %v", uri, resp.StatusCode)
 
 	if resp.StatusCode == http.StatusOK {
 		return resp.Body, nil
@@ -65,7 +65,7 @@ func (s *httpStore) Write(name string, data io.Reader) error {
 		return errors.New("'/' not allowed in name when writing bundles.")
 	}
 	uri := s.rootURI + name
-	log.Printf("Posting %s", uri)
+	log.Info("Posting %s", uri)
 	resp, err := s.client.Post(uri, "text/plain", data)
 	if err == nil {
 		defer resp.Body.Close()
@@ -74,6 +74,6 @@ func (s *httpStore) Write(name string, data io.Reader) error {
 			return errors.New(resp.Status + ": " + string(data))
 		}
 	}
-	log.Printf("Posted %s, err: %v", uri, err)
+	log.Info("Posted %s, err: %v", uri, err)
 	return err
 }

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -38,7 +38,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) HandleUpload(w http.ResponseWriter, req *http.Request) {
-	log.Info("Uploading %v, %v", req.Host, req.URL)
+	log.Debug("Uploading %v, %v", req.Host, req.URL)
 	defer s.stat.Latency("uploadLatency_ms").Time().Stop()
 	s.stat.Counter("uploadCounter").Inc(1)
 	bundleName := strings.TrimPrefix(req.URL.Path, "/bundle/")
@@ -67,7 +67,7 @@ func (s *Server) HandleUpload(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) HandleDownload(w http.ResponseWriter, req *http.Request) {
-	log.Info("Downloading %v %v", req.Host, req.URL)
+	log.Debug("Downloading %v %v", req.Host, req.URL)
 	defer s.stat.Latency("downloadLatency_ms").Time().Stop()
 	s.stat.Counter("downloadCounter").Inc(1)
 	bundleName := strings.TrimPrefix(req.URL.Path, "/bundle/")

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -2,7 +2,7 @@ package bundlestore
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"net/http"
 	"regexp"

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -2,8 +2,8 @@ package bundlestore
 
 import (
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -38,7 +38,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) HandleUpload(w http.ResponseWriter, req *http.Request) {
-	log.Printf("Uploading %v, %v", req.Host, req.URL)
+	log.Info("Uploading %v, %v", req.Host, req.URL)
 	defer s.stat.Latency("uploadLatency_ms").Time().Stop()
 	s.stat.Counter("uploadCounter").Inc(1)
 	bundleName := strings.TrimPrefix(req.URL.Path, "/bundle/")
@@ -67,7 +67,7 @@ func (s *Server) HandleUpload(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) HandleDownload(w http.ResponseWriter, req *http.Request) {
-	log.Printf("Downloading %v %v", req.Host, req.URL)
+	log.Info("Downloading %v %v", req.Host, req.URL)
 	defer s.stat.Latency("downloadLatency_ms").Time().Stop()
 	s.stat.Counter("downloadCounter").Inc(1)
 	bundleName := strings.TrimPrefix(req.URL.Path, "/bundle/")

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -2,7 +2,7 @@ package bundlestore
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"net/http"
 	"regexp"

--- a/snapshot/bundlestore/server.go
+++ b/snapshot/bundlestore/server.go
@@ -38,7 +38,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) HandleUpload(w http.ResponseWriter, req *http.Request) {
-	log.Debug("Uploading %v, %v", req.Host, req.URL)
+	log.Info("Uploading %v, %v", req.Host, req.URL)
 	defer s.stat.Latency("uploadLatency_ms").Time().Stop()
 	s.stat.Counter("uploadCounter").Inc(1)
 	bundleName := strings.TrimPrefix(req.URL.Path, "/bundle/")
@@ -67,7 +67,7 @@ func (s *Server) HandleUpload(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) HandleDownload(w http.ResponseWriter, req *http.Request) {
-	log.Debug("Downloading %v %v", req.Host, req.URL)
+	log.Info("Downloading %v %v", req.Host, req.URL)
 	defer s.stat.Latency("downloadLatency_ms").Time().Stop()
 	s.stat.Counter("downloadCounter").Inc(1)
 	bundleName := strings.TrimPrefix(req.URL.Path, "/bundle/")

--- a/snapshot/file_backed.go
+++ b/snapshot/file_backed.go
@@ -1,7 +1,7 @@
 package snapshot
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io/ioutil"
 	"os"
 

--- a/snapshot/file_backed.go
+++ b/snapshot/file_backed.go
@@ -1,8 +1,8 @@
 package snapshot
 
 import (
+	log "github.com/inconshreveable/log15"
 	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/scootdev/scoot/fs/perf"
@@ -92,8 +92,8 @@ func (i *fileBackedFileInfo) IsExec() bool {
 func (s *fileBackedSnapshot) Readdirents(name string) ([]Dirent, error) {
 	// TODO(dbentley): handle directories too big to read in one go
 	if Trace {
-		log.Print("Snap: Readdirents entry ", name)
-		defer log.Print("Snap: Readdirents exit ", name)
+		log.Info("Snap: Readdirents entry ", name)
+		defer log.Info("Snap: Readdirents exit ", name)
 	}
 
 	// TODO(dbentley): find a way to keep the file open instead of opening it here

--- a/snapshot/file_backed.go
+++ b/snapshot/file_backed.go
@@ -92,8 +92,8 @@ func (i *fileBackedFileInfo) IsExec() bool {
 func (s *fileBackedSnapshot) Readdirents(name string) ([]Dirent, error) {
 	// TODO(dbentley): handle directories too big to read in one go
 	if Trace {
-		log.Info("Snap: Readdirents entry ", name)
-		defer log.Info("Snap: Readdirents exit ", name)
+		log.Debug("Snap: Readdirents entry ", name)
+		defer log.Debug("Snap: Readdirents exit ", name)
 	}
 
 	// TODO(dbentley): find a way to keep the file open instead of opening it here

--- a/snapshot/file_backed.go
+++ b/snapshot/file_backed.go
@@ -1,7 +1,7 @@
 package snapshot
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io/ioutil"
 	"os"
 

--- a/snapshot/file_backed.go
+++ b/snapshot/file_backed.go
@@ -92,8 +92,8 @@ func (i *fileBackedFileInfo) IsExec() bool {
 func (s *fileBackedSnapshot) Readdirents(name string) ([]Dirent, error) {
 	// TODO(dbentley): handle directories too big to read in one go
 	if Trace {
-		log.Debug("Snap: Readdirents entry ", name)
-		defer log.Debug("Snap: Readdirents exit ", name)
+		log.Info("Snap: Readdirents entry ", name)
+		defer log.Info("Snap: Readdirents exit ", name)
 	}
 
 	// TODO(dbentley): find a way to keep the file open instead of opening it here

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -191,9 +191,9 @@ func (s *bundlestoreSnapshot) Kind() snapshotKind { return s.kind }
 func (s *bundlestoreSnapshot) SHA() string        { return s.sha }
 
 func (s *bundlestoreSnapshot) Download(db *DB) error {
-	log.Debug("Downloading sha: %s", s.SHA())
+	log.Info("Downloading sha: %s", s.SHA())
 	if err := db.shaPresent(s.SHA()); err == nil {
-		log.Debug("We already have sha: %s, returning from Download()", s.SHA())
+		log.Info("We already have sha: %s, returning from Download()", s.SHA())
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// TODO(dbentley): keep stats about how long it takes to unbundle
 	filename, err := s.downloadBundle(db)
 	if err != nil {
-		log.Debug("Unable to download bundle: ", err)
+		log.Info("Unable to download bundle: ", err)
 		return err
 	}
 
@@ -209,14 +209,14 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// this will succeed if we have all of the prerequisite objects
 
 	if _, err = db.dataRepo.Run("bundle", "unbundle", filename); err == nil {
-		log.Debug("Unbundling got the sha: %s, returning from Download()", s.SHA())
+		log.Info("Unbundling got the sha: %s, returning from Download()", s.SHA())
 		return db.shaPresent(s.sha)
 	}
 
 	// we couldn't unbundle
 	// see if it's because we're missing prereqs
 	if exitError := err.(*exec.ExitError); exitError == nil || !strings.Contains(string(exitError.Stderr), "error: Repository lacks these prerequisite commits:") {
-		log.Debug("Can't find sha: ", s.SHA(), " and prereqs aren't the problem, returning err: ", err.Error())
+		log.Info("Can't find sha: ", s.SHA(), " and prereqs aren't the problem, returning err: ", err.Error())
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// Now we've got the bundle for C3, which depends on C2, but we only have C1, so we have to
 	// update our stream.
 	if err := db.stream.updateStream(s.streamName, db); err != nil {
-		log.Debug("Couldn't download sha: %s, updateStream returned error: %s", s.SHA(), err.Error())
+		log.Info("Couldn't download sha: %s, updateStream returned error: %s", s.SHA(), err.Error())
 		return err
 	}
 
@@ -238,7 +238,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 		// if we still can't unbundle, then the bundle might be corrupt or the
 		// prereqs might not be in the stream, or maybe the git server is serving us
 		// stale data.
-		log.Debug("Couldn't download sha: %s, the final unbundling attempt returned error: %s", s.SHA(), err.Error())
+		log.Info("Couldn't download sha: %s, the final unbundling attempt returned error: %s", s.SHA(), err.Error())
 		return err
 	}
 

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -3,7 +3,7 @@ package gitdb
 import (
 	"errors"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"os"
 	"os/exec"

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -3,8 +3,8 @@ package gitdb
 import (
 	"errors"
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -191,9 +191,9 @@ func (s *bundlestoreSnapshot) Kind() snapshotKind { return s.kind }
 func (s *bundlestoreSnapshot) SHA() string        { return s.sha }
 
 func (s *bundlestoreSnapshot) Download(db *DB) error {
-	log.Printf("Downloading sha: %s", s.SHA())
+	log.Info("Downloading sha: %s", s.SHA())
 	if err := db.shaPresent(s.SHA()); err == nil {
-		log.Printf("We already have sha: %s, returning from Download()", s.SHA())
+		log.Info("We already have sha: %s, returning from Download()", s.SHA())
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// TODO(dbentley): keep stats about how long it takes to unbundle
 	filename, err := s.downloadBundle(db)
 	if err != nil {
-		log.Print("Unable to download bundle: ", err)
+		log.Info("Unable to download bundle: ", err)
 		return err
 	}
 
@@ -209,14 +209,14 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// this will succeed if we have all of the prerequisite objects
 
 	if _, err = db.dataRepo.Run("bundle", "unbundle", filename); err == nil {
-		log.Printf("Unbundling got the sha: %s, returning from Download()", s.SHA())
+		log.Info("Unbundling got the sha: %s, returning from Download()", s.SHA())
 		return db.shaPresent(s.sha)
 	}
 
 	// we couldn't unbundle
 	// see if it's because we're missing prereqs
 	if exitError := err.(*exec.ExitError); exitError == nil || !strings.Contains(string(exitError.Stderr), "error: Repository lacks these prerequisite commits:") {
-		log.Print("Can't find sha: ", s.SHA(), " and prereqs aren't the problem, returning err: ", err.Error())
+		log.Info("Can't find sha: ", s.SHA(), " and prereqs aren't the problem, returning err: ", err.Error())
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// Now we've got the bundle for C3, which depends on C2, but we only have C1, so we have to
 	// update our stream.
 	if err := db.stream.updateStream(s.streamName, db); err != nil {
-		log.Printf("Couldn't download sha: %s, updateStream returned error: %s", s.SHA(), err.Error())
+		log.Info("Couldn't download sha: %s, updateStream returned error: %s", s.SHA(), err.Error())
 		return err
 	}
 
@@ -238,7 +238,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 		// if we still can't unbundle, then the bundle might be corrupt or the
 		// prereqs might not be in the stream, or maybe the git server is serving us
 		// stale data.
-		log.Printf("Couldn't download sha: %s, the final unbundling attempt returned error: %s", s.SHA(), err.Error())
+		log.Info("Couldn't download sha: %s, the final unbundling attempt returned error: %s", s.SHA(), err.Error())
 		return err
 	}
 

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -191,9 +191,9 @@ func (s *bundlestoreSnapshot) Kind() snapshotKind { return s.kind }
 func (s *bundlestoreSnapshot) SHA() string        { return s.sha }
 
 func (s *bundlestoreSnapshot) Download(db *DB) error {
-	log.Info("Downloading sha: %s", s.SHA())
+	log.Debug("Downloading sha: %s", s.SHA())
 	if err := db.shaPresent(s.SHA()); err == nil {
-		log.Info("We already have sha: %s, returning from Download()", s.SHA())
+		log.Debug("We already have sha: %s, returning from Download()", s.SHA())
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// TODO(dbentley): keep stats about how long it takes to unbundle
 	filename, err := s.downloadBundle(db)
 	if err != nil {
-		log.Info("Unable to download bundle: ", err)
+		log.Debug("Unable to download bundle: ", err)
 		return err
 	}
 
@@ -209,14 +209,14 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// this will succeed if we have all of the prerequisite objects
 
 	if _, err = db.dataRepo.Run("bundle", "unbundle", filename); err == nil {
-		log.Info("Unbundling got the sha: %s, returning from Download()", s.SHA())
+		log.Debug("Unbundling got the sha: %s, returning from Download()", s.SHA())
 		return db.shaPresent(s.sha)
 	}
 
 	// we couldn't unbundle
 	// see if it's because we're missing prereqs
 	if exitError := err.(*exec.ExitError); exitError == nil || !strings.Contains(string(exitError.Stderr), "error: Repository lacks these prerequisite commits:") {
-		log.Info("Can't find sha: ", s.SHA(), " and prereqs aren't the problem, returning err: ", err.Error())
+		log.Debug("Can't find sha: ", s.SHA(), " and prereqs aren't the problem, returning err: ", err.Error())
 		return err
 	}
 
@@ -230,7 +230,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 	// Now we've got the bundle for C3, which depends on C2, but we only have C1, so we have to
 	// update our stream.
 	if err := db.stream.updateStream(s.streamName, db); err != nil {
-		log.Info("Couldn't download sha: %s, updateStream returned error: %s", s.SHA(), err.Error())
+		log.Debug("Couldn't download sha: %s, updateStream returned error: %s", s.SHA(), err.Error())
 		return err
 	}
 
@@ -238,7 +238,7 @@ func (s *bundlestoreSnapshot) Download(db *DB) error {
 		// if we still can't unbundle, then the bundle might be corrupt or the
 		// prereqs might not be in the stream, or maybe the git server is serving us
 		// stale data.
-		log.Info("Couldn't download sha: %s, the final unbundling attempt returned error: %s", s.SHA(), err.Error())
+		log.Debug("Couldn't download sha: %s, the final unbundling attempt returned error: %s", s.SHA(), err.Error())
 		return err
 	}
 

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -3,7 +3,7 @@ package gitdb
 import (
 	"errors"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"os"
 	"os/exec"

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -2,7 +2,7 @@ package gitdb
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"path/filepath"
 

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -53,7 +53,7 @@ func (db *DB) checkout(id snap.ID) (path string, err error) {
 	case kindGitCommitSnapshot:
 		// For GitCommitSnapshot's, we use dataRepo's work tree.
 		if id == db.currentSnapID {
-			log.Debug("Using cached checkout for id=%s", id)
+			log.Info("Using cached checkout for id=%s", id)
 			return db.dataRepo.Dir(), nil
 		}
 		path, err := db.checkoutGitCommitSnapshot(v.SHA())

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -53,7 +53,7 @@ func (db *DB) checkout(id snap.ID) (path string, err error) {
 	case kindGitCommitSnapshot:
 		// For GitCommitSnapshot's, we use dataRepo's work tree.
 		if id == db.currentSnapID {
-			log.Info("Using cached checkout for id=%s", id)
+			log.Debug("Using cached checkout for id=%s", id)
 			return db.dataRepo.Dir(), nil
 		}
 		path, err := db.checkoutGitCommitSnapshot(v.SHA())

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -2,7 +2,7 @@ package gitdb
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"path/filepath"
 
@@ -53,7 +53,7 @@ func (db *DB) checkout(id snap.ID) (path string, err error) {
 	case kindGitCommitSnapshot:
 		// For GitCommitSnapshot's, we use dataRepo's work tree.
 		if id == db.currentSnapID {
-			log.Printf("Using cached checkout for id=%s", id)
+			log.Info("Using cached checkout for id=%s", id)
 			return db.dataRepo.Dir(), nil
 		}
 		path, err := db.checkoutGitCommitSnapshot(v.SHA())

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -2,7 +2,7 @@ package gitdb
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"path/filepath"
 

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -3,7 +3,7 @@ package gitdb
 import (
 	"flag"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -3,8 +3,8 @@ package gitdb
 import (
 	"flag"
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -604,7 +604,7 @@ func TestMain(m *testing.M) {
 	fixture, err = setup()
 	defer fixture.close()
 	if err != nil {
-		log.Fatal(err)
+		log.Crit(err.Error())
 	}
 	result := m.Run()
 	// we need to call fixture.close() here because the defer we've registered

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -3,7 +3,7 @@ package gitdb
 import (
 	"flag"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -2,7 +2,7 @@ package gitfiler
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os/exec"
 
 	"github.com/scootdev/scoot/common/stats"

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -2,7 +2,7 @@ package gitfiler
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os/exec"
 
 	"github.com/scootdev/scoot/common/stats"
@@ -40,13 +40,13 @@ func (c *refCloner) Init(stat stats.StatsReceiver) (*repo.Repository, error) {
 
 	// We probably ought to use a separate git dir so that processes can't mess up .git
 	cmd := exec.Command("git", "clone", "--reference", ref.Dir(), ref.Dir(), cloneDir.Dir)
-	log.Println("gitfiler.refCloner.clone: Cloning", cmd)
+	log.Info("gitfiler.refCloner.clone: Cloning", cmd)
 	err = cmd.Run()
 	if err != nil {
 		stat.Counter("clonerInitFailures").Inc(1)
 		return nil, fmt.Errorf("gitfiler.refCloner.clone: error cloning: %v", err)
 	}
-	log.Println("gitfiler.refCloner.clone: Cloning complete")
+	log.Info("gitfiler.refCloner.clone: Cloning complete")
 
 	initTime.Stop()
 	return repo.NewRepository(cloneDir.Dir)

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -40,13 +40,13 @@ func (c *refCloner) Init(stat stats.StatsReceiver) (*repo.Repository, error) {
 
 	// We probably ought to use a separate git dir so that processes can't mess up .git
 	cmd := exec.Command("git", "clone", "--reference", ref.Dir(), ref.Dir(), cloneDir.Dir)
-	log.Info("gitfiler.refCloner.clone: Cloning", cmd)
+	log.Debug("gitfiler.refCloner.clone: Cloning", cmd)
 	err = cmd.Run()
 	if err != nil {
 		stat.Counter("clonerInitFailures").Inc(1)
 		return nil, fmt.Errorf("gitfiler.refCloner.clone: error cloning: %v", err)
 	}
-	log.Info("gitfiler.refCloner.clone: Cloning complete")
+	log.Debug("gitfiler.refCloner.clone: Cloning complete")
 
 	initTime.Stop()
 	return repo.NewRepository(cloneDir.Dir)

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -40,13 +40,13 @@ func (c *refCloner) Init(stat stats.StatsReceiver) (*repo.Repository, error) {
 
 	// We probably ought to use a separate git dir so that processes can't mess up .git
 	cmd := exec.Command("git", "clone", "--reference", ref.Dir(), ref.Dir(), cloneDir.Dir)
-	log.Debug("gitfiler.refCloner.clone: Cloning", cmd)
+	log.Info("gitfiler.refCloner.clone: Cloning", cmd)
 	err = cmd.Run()
 	if err != nil {
 		stat.Counter("clonerInitFailures").Inc(1)
 		return nil, fmt.Errorf("gitfiler.refCloner.clone: error cloning: %v", err)
 	}
-	log.Debug("gitfiler.refCloner.clone: Cloning complete")
+	log.Info("gitfiler.refCloner.clone: Cloning complete")
 
 	initTime.Stop()
 	return repo.NewRepository(cloneDir.Dir)

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -2,7 +2,7 @@ package gitfiler
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os/exec"
 
 	"github.com/scootdev/scoot/common/stats"

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -35,11 +35,11 @@ func (r *Repository) Command(args ...string) *exec.Cmd {
 
 // RunCmd runs cmd (that must have been created by Command), returning its output and error
 func (r *Repository) RunCmd(cmd *exec.Cmd) (string, error) {
-	log.Info("repo.Repository.Run", cmd.Args[1:])
+	log.Debug("repo.Repository.Run", cmd.Args[1:])
 	data, err := cmd.Output()
-	log.Info("repo.Repository.Run complete", err)
+	log.Debug("repo.Repository.Run complete", err)
 	if err != nil && err.(*exec.ExitError) != nil {
-		log.Info("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
+		log.Debug("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
 	}
 	return string(data), err
 }
@@ -83,7 +83,7 @@ func NewRepository(dir string) (*Repository, error) {
 		return nil, err
 	}
 	topLevel = strings.Replace(topLevel, "\n", "", -1)
-	log.Info("git.NewRepository:", dir, topLevel)
+	log.Debug("git.NewRepository:", dir, topLevel)
 	r.dir = topLevel
 	return r, nil
 }

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -5,7 +5,7 @@ package repo
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"os/exec"
 	"strings"

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -35,11 +35,11 @@ func (r *Repository) Command(args ...string) *exec.Cmd {
 
 // RunCmd runs cmd (that must have been created by Command), returning its output and error
 func (r *Repository) RunCmd(cmd *exec.Cmd) (string, error) {
-	log.Debug("repo.Repository.Run", cmd.Args[1:])
+	log.Info("repo.Repository.Run", cmd.Args[1:])
 	data, err := cmd.Output()
-	log.Debug("repo.Repository.Run complete", err)
+	log.Info("repo.Repository.Run complete", err)
 	if err != nil && err.(*exec.ExitError) != nil {
-		log.Debug("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
+		log.Info("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
 	}
 	return string(data), err
 }
@@ -83,7 +83,7 @@ func NewRepository(dir string) (*Repository, error) {
 		return nil, err
 	}
 	topLevel = strings.Replace(topLevel, "\n", "", -1)
-	log.Debug("git.NewRepository:", dir, topLevel)
+	log.Info("git.NewRepository:", dir, topLevel)
 	r.dir = topLevel
 	return r, nil
 }

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -5,7 +5,7 @@ package repo
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"os/exec"
 	"strings"

--- a/snapshot/git/repo/repo.go
+++ b/snapshot/git/repo/repo.go
@@ -5,7 +5,7 @@ package repo
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"os/exec"
 	"strings"
@@ -35,11 +35,11 @@ func (r *Repository) Command(args ...string) *exec.Cmd {
 
 // RunCmd runs cmd (that must have been created by Command), returning its output and error
 func (r *Repository) RunCmd(cmd *exec.Cmd) (string, error) {
-	log.Println("repo.Repository.Run", cmd.Args[1:])
+	log.Info("repo.Repository.Run", cmd.Args[1:])
 	data, err := cmd.Output()
-	log.Println("repo.Repository.Run complete", err)
+	log.Info("repo.Repository.Run complete", err)
 	if err != nil && err.(*exec.ExitError) != nil {
-		log.Println("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
+		log.Info("repo.Repository.Run error:", string(err.(*exec.ExitError).Stderr))
 	}
 	return string(data), err
 }
@@ -83,7 +83,7 @@ func NewRepository(dir string) (*Repository, error) {
 		return nil, err
 	}
 	topLevel = strings.Replace(topLevel, "\n", "", -1)
-	log.Println("git.NewRepository:", dir, topLevel)
+	log.Info("git.NewRepository:", dir, topLevel)
 	r.dir = topLevel
 	return r, nil
 }

--- a/snapshot/utils/checkout/checkout.go
+++ b/snapshot/utils/checkout/checkout.go
@@ -7,7 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"io"
 	"io/ioutil"
 	"os"

--- a/snapshot/utils/checkout/checkout.go
+++ b/snapshot/utils/checkout/checkout.go
@@ -27,14 +27,14 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	if useSnapshot {
 		fi, err := ctx.snap.Stat(relPath)
 		if err != nil {
-			log.Info("Couldn't Stat", err, relPath)
+			log.Debug("Couldn't Stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
 	} else {
 		fi, err := os.Stat(path.Join(ctx.srcRoot, relPath))
 		if err != nil {
-			log.Info("Couldn't stat", err, relPath)
+			log.Debug("Couldn't stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
@@ -50,7 +50,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		if useSnapshot {
 			f, err := ctx.snap.Open(relPath)
 			if err != nil {
-				log.Info("Couldn't open", err, relPath)
+				log.Debug("Couldn't open", err, relPath)
 				return
 			}
 			defer f.Close()
@@ -58,7 +58,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		} else {
 			f, err := os.Open(path.Join(ctx.srcRoot, relPath))
 			if err != nil {
-				log.Info("Couldn't open", err, relPath)
+				log.Debug("Couldn't open", err, relPath)
 				return
 			}
 			defer f.Close()
@@ -66,11 +66,11 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		}
 		bs, err = ioutil.ReadAll(r)
 		if err != nil {
-			log.Info("Couldn't read", err)
+			log.Debug("Couldn't read", err)
 		}
 		err = ioutil.WriteFile(dstPath, bs, 0777)
 		if err != nil {
-			log.Info("Couldn't write", err, relPath, dstPath)
+			log.Debug("Couldn't write", err, relPath, dstPath)
 		}
 		return
 	}
@@ -79,7 +79,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	if useSnapshot {
 		childDirents, err := ctx.snap.Readdirents(relPath)
 		if err != nil {
-			log.Info("Couldn't ReadDir", err, relPath)
+			log.Debug("Couldn't ReadDir", err, relPath)
 			return
 		}
 		children = make([]string, len(childDirents))
@@ -89,13 +89,13 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	} else {
 		f, err := os.Open(path.Join(ctx.srcRoot, relPath))
 		if err != nil {
-			log.Info("Couldn't open", err, relPath)
+			log.Debug("Couldn't open", err, relPath)
 			return
 		}
 		defer f.Close()
 		children, err = f.Readdirnames(0)
 		if err != nil {
-			log.Info("Couldn't Readdirnames", err, relPath)
+			log.Debug("Couldn't Readdirnames", err, relPath)
 			return
 		}
 	}

--- a/snapshot/utils/checkout/checkout.go
+++ b/snapshot/utils/checkout/checkout.go
@@ -7,9 +7,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	log "github.com/inconshreveable/log15"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 
@@ -27,14 +27,14 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	if useSnapshot {
 		fi, err := ctx.snap.Stat(relPath)
 		if err != nil {
-			log.Print("Couldn't Stat", err, relPath)
+			log.Info("Couldn't Stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
 	} else {
 		fi, err := os.Stat(path.Join(ctx.srcRoot, relPath))
 		if err != nil {
-			log.Print("Couldn't stat", err, relPath)
+			log.Info("Couldn't stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
@@ -50,7 +50,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		if useSnapshot {
 			f, err := ctx.snap.Open(relPath)
 			if err != nil {
-				log.Print("Couldn't open", err, relPath)
+				log.Info("Couldn't open", err, relPath)
 				return
 			}
 			defer f.Close()
@@ -58,7 +58,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		} else {
 			f, err := os.Open(path.Join(ctx.srcRoot, relPath))
 			if err != nil {
-				log.Print("Couldn't open", err, relPath)
+				log.Info("Couldn't open", err, relPath)
 				return
 			}
 			defer f.Close()
@@ -66,11 +66,11 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		}
 		bs, err = ioutil.ReadAll(r)
 		if err != nil {
-			log.Print("Couldn't read", err)
+			log.Info("Couldn't read", err)
 		}
 		err = ioutil.WriteFile(dstPath, bs, 0777)
 		if err != nil {
-			log.Print("Couldn't write", err, relPath, dstPath)
+			log.Info("Couldn't write", err, relPath, dstPath)
 		}
 		return
 	}
@@ -79,7 +79,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	if useSnapshot {
 		childDirents, err := ctx.snap.Readdirents(relPath)
 		if err != nil {
-			log.Print("Couldn't ReadDir", err, relPath)
+			log.Info("Couldn't ReadDir", err, relPath)
 			return
 		}
 		children = make([]string, len(childDirents))
@@ -89,13 +89,13 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	} else {
 		f, err := os.Open(path.Join(ctx.srcRoot, relPath))
 		if err != nil {
-			log.Print("Couldn't open", err, relPath)
+			log.Info("Couldn't open", err, relPath)
 			return
 		}
 		defer f.Close()
 		children, err = f.Readdirnames(0)
 		if err != nil {
-			log.Print("Couldn't Readdirnames", err, relPath)
+			log.Info("Couldn't Readdirnames", err, relPath)
 			return
 		}
 	}
@@ -117,12 +117,12 @@ func init() {
 func main() {
 	flag.Parse()
 	if srcRoot == "" || dstRoot == "" {
-		log.Fatal("-src and -dst must both be set")
+		log.Crit("-src and -dst must both be set")
 	}
 	snaps := snapshot.NewFileBackedSnapshots(srcRoot)
 	snap, err := snaps.Get("foo")
 	if err != nil {
-		log.Fatal("Invalid ID \"foo\":", err)
+		log.Crit("Invalid ID \"foo\":", err)
 	}
 	ctx := checkoutContext{srcRoot: srcRoot, snap: snap, dstRoot: dstRoot}
 	copyFiles(&ctx, "")

--- a/snapshot/utils/checkout/checkout.go
+++ b/snapshot/utils/checkout/checkout.go
@@ -27,14 +27,14 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	if useSnapshot {
 		fi, err := ctx.snap.Stat(relPath)
 		if err != nil {
-			log.Debug("Couldn't Stat", err, relPath)
+			log.Info("Couldn't Stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
 	} else {
 		fi, err := os.Stat(path.Join(ctx.srcRoot, relPath))
 		if err != nil {
-			log.Debug("Couldn't stat", err, relPath)
+			log.Info("Couldn't stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
@@ -50,7 +50,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		if useSnapshot {
 			f, err := ctx.snap.Open(relPath)
 			if err != nil {
-				log.Debug("Couldn't open", err, relPath)
+				log.Info("Couldn't open", err, relPath)
 				return
 			}
 			defer f.Close()
@@ -58,7 +58,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		} else {
 			f, err := os.Open(path.Join(ctx.srcRoot, relPath))
 			if err != nil {
-				log.Debug("Couldn't open", err, relPath)
+				log.Info("Couldn't open", err, relPath)
 				return
 			}
 			defer f.Close()
@@ -66,11 +66,11 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 		}
 		bs, err = ioutil.ReadAll(r)
 		if err != nil {
-			log.Debug("Couldn't read", err)
+			log.Info("Couldn't read", err)
 		}
 		err = ioutil.WriteFile(dstPath, bs, 0777)
 		if err != nil {
-			log.Debug("Couldn't write", err, relPath, dstPath)
+			log.Info("Couldn't write", err, relPath, dstPath)
 		}
 		return
 	}
@@ -79,7 +79,7 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	if useSnapshot {
 		childDirents, err := ctx.snap.Readdirents(relPath)
 		if err != nil {
-			log.Debug("Couldn't ReadDir", err, relPath)
+			log.Info("Couldn't ReadDir", err, relPath)
 			return
 		}
 		children = make([]string, len(childDirents))
@@ -89,13 +89,13 @@ func copyFiles(ctx *checkoutContext, relPath string) {
 	} else {
 		f, err := os.Open(path.Join(ctx.srcRoot, relPath))
 		if err != nil {
-			log.Debug("Couldn't open", err, relPath)
+			log.Info("Couldn't open", err, relPath)
 			return
 		}
 		defer f.Close()
 		children, err = f.Readdirnames(0)
 		if err != nil {
-			log.Debug("Couldn't Readdirnames", err, relPath)
+			log.Info("Couldn't Readdirnames", err, relPath)
 			return
 		}
 	}

--- a/snapshot/utils/checkout/checkout.go
+++ b/snapshot/utils/checkout/checkout.go
@@ -7,7 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"io"
 	"io/ioutil"
 	"os"

--- a/snapshot/utils/countfiles/countfiles.go
+++ b/snapshot/utils/countfiles/countfiles.go
@@ -7,7 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"os"
 	"path"
 
@@ -24,14 +24,14 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	if useSnapshot {
 		fi, err := ctx.snap.Stat(relPath)
 		if err != nil {
-			log.Print("Couldn't Stat", err, relPath)
+			log.Info("Couldn't Stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
 	} else {
 		fi, err := os.Stat(path.Join(ctx.root, relPath))
 		if err != nil {
-			log.Print("Couldn't stat", err, relPath)
+			log.Info("Couldn't stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
@@ -44,7 +44,7 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	if useSnapshot {
 		childDirents, err := ctx.snap.Readdirents(relPath)
 		if err != nil {
-			log.Print("Couldn't ReadDir", err, relPath)
+			log.Info("Couldn't ReadDir", err, relPath)
 			return
 		}
 		children = make([]string, len(childDirents))
@@ -54,13 +54,13 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	} else {
 		f, err := os.Open(path.Join(ctx.root, relPath))
 		if err != nil {
-			log.Print("Couldn't open", err, relPath)
+			log.Info("Couldn't open", err, relPath)
 			return
 		}
 		defer f.Close()
 		children, err = f.Readdirnames(0)
 		if err != nil {
-			log.Print("Couldn't Readdirnames", err, relPath)
+			log.Info("Couldn't Readdirnames", err, relPath)
 			return
 		}
 	}
@@ -80,12 +80,12 @@ func init() {
 func main() {
 	flag.Parse()
 	if root == "" {
-		log.Fatal("-root not set")
+		log.Crit("-root not set")
 	}
 	snaps := snapshot.NewFileBackedSnapshots(root)
 	snap, err := snaps.Get("foo")
 	if err != nil {
-		log.Fatal("Invalid ID \"foo\":", err)
+		log.Crit("Invalid ID \"foo\":", err)
 	}
 	ctx := countContext{root: root, snap: snap}
 	var fileCount int

--- a/snapshot/utils/countfiles/countfiles.go
+++ b/snapshot/utils/countfiles/countfiles.go
@@ -24,14 +24,14 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	if useSnapshot {
 		fi, err := ctx.snap.Stat(relPath)
 		if err != nil {
-			log.Info("Couldn't Stat", err, relPath)
+			log.Debug("Couldn't Stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
 	} else {
 		fi, err := os.Stat(path.Join(ctx.root, relPath))
 		if err != nil {
-			log.Info("Couldn't stat", err, relPath)
+			log.Debug("Couldn't stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
@@ -44,7 +44,7 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	if useSnapshot {
 		childDirents, err := ctx.snap.Readdirents(relPath)
 		if err != nil {
-			log.Info("Couldn't ReadDir", err, relPath)
+			log.Debug("Couldn't ReadDir", err, relPath)
 			return
 		}
 		children = make([]string, len(childDirents))
@@ -54,13 +54,13 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	} else {
 		f, err := os.Open(path.Join(ctx.root, relPath))
 		if err != nil {
-			log.Info("Couldn't open", err, relPath)
+			log.Debug("Couldn't open", err, relPath)
 			return
 		}
 		defer f.Close()
 		children, err = f.Readdirnames(0)
 		if err != nil {
-			log.Info("Couldn't Readdirnames", err, relPath)
+			log.Debug("Couldn't Readdirnames", err, relPath)
 			return
 		}
 	}

--- a/snapshot/utils/countfiles/countfiles.go
+++ b/snapshot/utils/countfiles/countfiles.go
@@ -24,14 +24,14 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	if useSnapshot {
 		fi, err := ctx.snap.Stat(relPath)
 		if err != nil {
-			log.Debug("Couldn't Stat", err, relPath)
+			log.Info("Couldn't Stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
 	} else {
 		fi, err := os.Stat(path.Join(ctx.root, relPath))
 		if err != nil {
-			log.Debug("Couldn't stat", err, relPath)
+			log.Info("Couldn't stat", err, relPath)
 			return
 		}
 		isDir = fi.IsDir()
@@ -44,7 +44,7 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	if useSnapshot {
 		childDirents, err := ctx.snap.Readdirents(relPath)
 		if err != nil {
-			log.Debug("Couldn't ReadDir", err, relPath)
+			log.Info("Couldn't ReadDir", err, relPath)
 			return
 		}
 		children = make([]string, len(childDirents))
@@ -54,13 +54,13 @@ func countFiles(ctx *countContext, count *int, relPath string) {
 	} else {
 		f, err := os.Open(path.Join(ctx.root, relPath))
 		if err != nil {
-			log.Debug("Couldn't open", err, relPath)
+			log.Info("Couldn't open", err, relPath)
 			return
 		}
 		defer f.Close()
 		children, err = f.Readdirnames(0)
 		if err != nil {
-			log.Debug("Couldn't Readdirnames", err, relPath)
+			log.Info("Couldn't Readdirnames", err, relPath)
 			return
 		}
 	}

--- a/snapshot/utils/countfiles/countfiles.go
+++ b/snapshot/utils/countfiles/countfiles.go
@@ -7,7 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"os"
 	"path"
 

--- a/snapshot/utils/countfiles/countfiles.go
+++ b/snapshot/utils/countfiles/countfiles.go
@@ -7,7 +7,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"os"
 	"path"
 

--- a/tests/testhelpers/clusterHelpers.go
+++ b/tests/testhelpers/clusterHelpers.go
@@ -1,7 +1,7 @@
 package testhelpers
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"time"
 
 	"github.com/scootdev/scoot/os/temp"
@@ -38,12 +38,12 @@ func CreateLocalTestCluster() (*setup.Cmds, error) {
 // Until a successful response is returned.
 func WaitForClusterToBeReady(client scoot.CloudScoot) {
 	status, err := client.GetStatus("testJobId")
-	log.Printf("Waiting for Cluster Status: %+v, Error: %v", status, err)
+	log.Info("Waiting for Cluster Status: %+v, Error: %v", status, err)
 
 	for err != nil {
 		time.Sleep(500 * time.Millisecond)
 		status, err = client.GetStatus("testJobId")
-		log.Printf("Waiting for Cluster Status: %+v, Error: %v", status, err)
+		log.Info("Waiting for Cluster Status: %+v, Error: %v", status, err)
 	}
 
 	return

--- a/tests/testhelpers/clusterHelpers.go
+++ b/tests/testhelpers/clusterHelpers.go
@@ -38,12 +38,12 @@ func CreateLocalTestCluster() (*setup.Cmds, error) {
 // Until a successful response is returned.
 func WaitForClusterToBeReady(client scoot.CloudScoot) {
 	status, err := client.GetStatus("testJobId")
-	log.Debug("Waiting for Cluster Status: %+v, Error: %v", status, err)
+	log.Info("Waiting for Cluster Status: %+v, Error: %v", status, err)
 
 	for err != nil {
 		time.Sleep(500 * time.Millisecond)
 		status, err = client.GetStatus("testJobId")
-		log.Debug("Waiting for Cluster Status: %+v, Error: %v", status, err)
+		log.Info("Waiting for Cluster Status: %+v, Error: %v", status, err)
 	}
 
 	return

--- a/tests/testhelpers/clusterHelpers.go
+++ b/tests/testhelpers/clusterHelpers.go
@@ -1,7 +1,7 @@
 package testhelpers
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"time"
 
 	"github.com/scootdev/scoot/os/temp"

--- a/tests/testhelpers/clusterHelpers.go
+++ b/tests/testhelpers/clusterHelpers.go
@@ -38,12 +38,12 @@ func CreateLocalTestCluster() (*setup.Cmds, error) {
 // Until a successful response is returned.
 func WaitForClusterToBeReady(client scoot.CloudScoot) {
 	status, err := client.GetStatus("testJobId")
-	log.Info("Waiting for Cluster Status: %+v, Error: %v", status, err)
+	log.Debug("Waiting for Cluster Status: %+v, Error: %v", status, err)
 
 	for err != nil {
 		time.Sleep(500 * time.Millisecond)
 		status, err = client.GetStatus("testJobId")
-		log.Info("Waiting for Cluster Status: %+v, Error: %v", status, err)
+		log.Debug("Waiting for Cluster Status: %+v, Error: %v", status, err)
 	}
 
 	return

--- a/tests/testhelpers/clusterHelpers.go
+++ b/tests/testhelpers/clusterHelpers.go
@@ -1,7 +1,7 @@
 package testhelpers
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"time"
 
 	"github.com/scootdev/scoot/os/temp"

--- a/tests/testhelpers/jobHelpers.go
+++ b/tests/testhelpers/jobHelpers.go
@@ -2,7 +2,7 @@ package testhelpers
 
 import (
 	"fmt"
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"math/rand"
 	"sort"
 	"time"

--- a/tests/testhelpers/jobHelpers.go
+++ b/tests/testhelpers/jobHelpers.go
@@ -44,7 +44,7 @@ func StartJob(client *scootapi.CloudScootClient, job *scoot.JobDefinition) strin
 		}
 		// retry starting job until it succeeds.
 		// this is useful for testing where we are restarting the scheduler
-		log.Info("Error Starting Job: Retrying %v", err)
+		log.Debug("Error Starting Job: Retrying %v", err)
 	}
 }
 
@@ -76,7 +76,7 @@ func WaitForJobsToCompleteAndLogStatus(
 
 				// if there is an error just continue
 				if err != nil {
-					log.Info("Error: Updating Job Status ID: %v will retry later, Error: %v", jobId, err)
+					log.Debug("Error: Updating Job Status ID: %v will retry later, Error: %v", jobId, err)
 					done = false
 				} else {
 					jobs[jobId] = currStatus
@@ -86,7 +86,7 @@ func WaitForJobsToCompleteAndLogStatus(
 		}
 		PrintJobs(jobs)
 		if done {
-			log.Info("Done")
+			log.Debug("Done")
 			return nil
 		}
 		time.Sleep(time.Second)
@@ -131,11 +131,11 @@ func PrintJobs(jobs map[string]*scoot.JobStatus) {
 		progs[i] = jobProgress{id: jobID, numTasks: len(tasks), numDone: numDone}
 	}
 
-	log.Info("Job Status")
+	log.Debug("Job Status")
 
-	log.Info("Waiting", byStatus[scoot.Status_NOT_STARTED])
-	log.Info("Running", progs)
-	log.Info("Done", byStatus[scoot.Status_COMPLETED])
+	log.Debug("Waiting", byStatus[scoot.Status_NOT_STARTED])
+	log.Debug("Running", progs)
+	log.Debug("Done", byStatus[scoot.Status_COMPLETED])
 }
 
 // Returns true if a job is completed or failed, false otherwise

--- a/tests/testhelpers/jobHelpers.go
+++ b/tests/testhelpers/jobHelpers.go
@@ -44,7 +44,7 @@ func StartJob(client *scootapi.CloudScootClient, job *scoot.JobDefinition) strin
 		}
 		// retry starting job until it succeeds.
 		// this is useful for testing where we are restarting the scheduler
-		log.Debug("Error Starting Job: Retrying %v", err)
+		log.Info("Error Starting Job: Retrying %v", err)
 	}
 }
 
@@ -76,7 +76,7 @@ func WaitForJobsToCompleteAndLogStatus(
 
 				// if there is an error just continue
 				if err != nil {
-					log.Debug("Error: Updating Job Status ID: %v will retry later, Error: %v", jobId, err)
+					log.Info("Error: Updating Job Status ID: %v will retry later, Error: %v", jobId, err)
 					done = false
 				} else {
 					jobs[jobId] = currStatus
@@ -86,7 +86,7 @@ func WaitForJobsToCompleteAndLogStatus(
 		}
 		PrintJobs(jobs)
 		if done {
-			log.Debug("Done")
+			log.Info("Done")
 			return nil
 		}
 		time.Sleep(time.Second)
@@ -131,11 +131,11 @@ func PrintJobs(jobs map[string]*scoot.JobStatus) {
 		progs[i] = jobProgress{id: jobID, numTasks: len(tasks), numDone: numDone}
 	}
 
-	log.Debug("Job Status")
+	log.Info("Job Status")
 
-	log.Debug("Waiting", byStatus[scoot.Status_NOT_STARTED])
-	log.Debug("Running", progs)
-	log.Debug("Done", byStatus[scoot.Status_COMPLETED])
+	log.Info("Waiting", byStatus[scoot.Status_NOT_STARTED])
+	log.Info("Running", progs)
+	log.Info("Done", byStatus[scoot.Status_COMPLETED])
 }
 
 // Returns true if a job is completed or failed, false otherwise

--- a/tests/testhelpers/jobHelpers.go
+++ b/tests/testhelpers/jobHelpers.go
@@ -2,7 +2,7 @@ package testhelpers
 
 import (
 	"fmt"
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"math/rand"
 	"sort"
 	"time"

--- a/tests/testhelpers/jobHelpers.go
+++ b/tests/testhelpers/jobHelpers.go
@@ -2,7 +2,7 @@ package testhelpers
 
 import (
 	"fmt"
-	"log"
+	log "github.com/inconshreveable/log15"
 	"math/rand"
 	"sort"
 	"time"
@@ -44,7 +44,7 @@ func StartJob(client *scootapi.CloudScootClient, job *scoot.JobDefinition) strin
 		}
 		// retry starting job until it succeeds.
 		// this is useful for testing where we are restarting the scheduler
-		log.Printf("Error Starting Job: Retrying %v", err)
+		log.Info("Error Starting Job: Retrying %v", err)
 	}
 }
 
@@ -76,7 +76,7 @@ func WaitForJobsToCompleteAndLogStatus(
 
 				// if there is an error just continue
 				if err != nil {
-					log.Printf("Error: Updating Job Status ID: %v will retry later, Error: %v", jobId, err)
+					log.Info("Error: Updating Job Status ID: %v will retry later, Error: %v", jobId, err)
 					done = false
 				} else {
 					jobs[jobId] = currStatus
@@ -86,7 +86,7 @@ func WaitForJobsToCompleteAndLogStatus(
 		}
 		PrintJobs(jobs)
 		if done {
-			log.Println("Done")
+			log.Info("Done")
 			return nil
 		}
 		time.Sleep(time.Second)
@@ -131,12 +131,11 @@ func PrintJobs(jobs map[string]*scoot.JobStatus) {
 		progs[i] = jobProgress{id: jobID, numTasks: len(tasks), numDone: numDone}
 	}
 
-	log.Println()
-	log.Println("Job Status")
+	log.Info("Job Status")
 
-	log.Println("Waiting", byStatus[scoot.Status_NOT_STARTED])
-	log.Println("Running", progs)
-	log.Println("Done", byStatus[scoot.Status_COMPLETED])
+	log.Info("Waiting", byStatus[scoot.Status_NOT_STARTED])
+	log.Info("Running", progs)
+	log.Info("Done", byStatus[scoot.Status_COMPLETED])
 }
 
 // Returns true if a job is completed or failed, false otherwise

--- a/workerapi/client/commands.go
+++ b/workerapi/client/commands.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"time"
 
 	"github.com/scootdev/scoot/runner"
@@ -28,10 +28,10 @@ func (rc *runCmd) run(cmd *cobra.Command, args []string) error {
 		Timeout:    rc.timeout,
 		SnapshotID: rc.snapshotID,
 	}
-	log.Printf("Calling run RPC to Cloud Worker:\n%s", cmdToRun)
+	log.Info("Calling run RPC to Cloud Worker:\n%s", cmdToRun)
 
 	status, err := rc.client.Run(cmdToRun)
-	log.Printf("%v\nError: %v\n", status, err)
+	log.Info("%v\nError: %v\n", status, err)
 	return nil
 }
 
@@ -48,10 +48,10 @@ func (ac *abortCmd) registerFlags(cmd *cobra.Command) {
 }
 
 func (ac *abortCmd) run(cmd *cobra.Command, args []string) error {
-	log.Println("Calling abort rpc to cloud worker", args)
+	log.Info("Calling abort rpc to cloud worker", args)
 
 	status, err := ac.client.Abort(runner.RunID(ac.runId))
-	log.Printf("%v\nError: %v\n", status, err)
+	log.Info("%v\nError: %v\n", status, err)
 	return nil
 }
 
@@ -63,10 +63,10 @@ type queryWorkerCmd struct {
 func (qc *queryWorkerCmd) registerFlags(cmd *cobra.Command) {}
 
 func (qc *queryWorkerCmd) run(cmd *cobra.Command, args []string) error {
-	log.Println("Calling queryworker rpc to cloud worker", args)
+	log.Info("Calling queryworker rpc to cloud worker", args)
 
 	status, err := qc.client.QueryWorker()
-	log.Printf("%v\nError: %v\n", status, err)
+	log.Info("%v\nError: %v\n", status, err)
 	return nil
 }
 

--- a/workerapi/client/commands.go
+++ b/workerapi/client/commands.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"time"
 
 	"github.com/scootdev/scoot/runner"

--- a/workerapi/client/commands.go
+++ b/workerapi/client/commands.go
@@ -28,10 +28,10 @@ func (rc *runCmd) run(cmd *cobra.Command, args []string) error {
 		Timeout:    rc.timeout,
 		SnapshotID: rc.snapshotID,
 	}
-	log.Info("Calling run RPC to Cloud Worker:\n%s", cmdToRun)
+	log.Debug("Calling run RPC to Cloud Worker:\n%s", cmdToRun)
 
 	status, err := rc.client.Run(cmdToRun)
-	log.Info("%v\nError: %v\n", status, err)
+	log.Debug("%v\nError: %v\n", status, err)
 	return nil
 }
 
@@ -48,10 +48,10 @@ func (ac *abortCmd) registerFlags(cmd *cobra.Command) {
 }
 
 func (ac *abortCmd) run(cmd *cobra.Command, args []string) error {
-	log.Info("Calling abort rpc to cloud worker", args)
+	log.Debug("Calling abort rpc to cloud worker", args)
 
 	status, err := ac.client.Abort(runner.RunID(ac.runId))
-	log.Info("%v\nError: %v\n", status, err)
+	log.Debug("%v\nError: %v\n", status, err)
 	return nil
 }
 
@@ -63,10 +63,10 @@ type queryWorkerCmd struct {
 func (qc *queryWorkerCmd) registerFlags(cmd *cobra.Command) {}
 
 func (qc *queryWorkerCmd) run(cmd *cobra.Command, args []string) error {
-	log.Info("Calling queryworker rpc to cloud worker", args)
+	log.Debug("Calling queryworker rpc to cloud worker", args)
 
 	status, err := qc.client.QueryWorker()
-	log.Info("%v\nError: %v\n", status, err)
+	log.Debug("%v\nError: %v\n", status, err)
 	return nil
 }
 

--- a/workerapi/client/commands.go
+++ b/workerapi/client/commands.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"time"
 
 	"github.com/scootdev/scoot/runner"

--- a/workerapi/client/commands.go
+++ b/workerapi/client/commands.go
@@ -28,10 +28,10 @@ func (rc *runCmd) run(cmd *cobra.Command, args []string) error {
 		Timeout:    rc.timeout,
 		SnapshotID: rc.snapshotID,
 	}
-	log.Debug("Calling run RPC to Cloud Worker:\n%s", cmdToRun)
+	log.Info("Calling run RPC to Cloud Worker:\n%s", cmdToRun)
 
 	status, err := rc.client.Run(cmdToRun)
-	log.Debug("%v\nError: %v\n", status, err)
+	log.Info("%v\nError: %v\n", status, err)
 	return nil
 }
 
@@ -48,10 +48,10 @@ func (ac *abortCmd) registerFlags(cmd *cobra.Command) {
 }
 
 func (ac *abortCmd) run(cmd *cobra.Command, args []string) error {
-	log.Debug("Calling abort rpc to cloud worker", args)
+	log.Info("Calling abort rpc to cloud worker", args)
 
 	status, err := ac.client.Abort(runner.RunID(ac.runId))
-	log.Debug("%v\nError: %v\n", status, err)
+	log.Info("%v\nError: %v\n", status, err)
 	return nil
 }
 
@@ -63,10 +63,10 @@ type queryWorkerCmd struct {
 func (qc *queryWorkerCmd) registerFlags(cmd *cobra.Command) {}
 
 func (qc *queryWorkerCmd) run(cmd *cobra.Command, args []string) error {
-	log.Debug("Calling queryworker rpc to cloud worker", args)
+	log.Info("Calling queryworker rpc to cloud worker", args)
 
 	status, err := qc.client.QueryWorker()
-	log.Debug("%v\nError: %v\n", status, err)
+	log.Info("%v\nError: %v\n", status, err)
 	return nil
 }
 

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -3,7 +3,7 @@
 package server
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 	"sync"
 	"time"
 

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -3,7 +3,7 @@
 package server
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 	"sync"
 	"time"
 
@@ -105,7 +105,7 @@ func (h *handler) QueryWorker() (*worker.WorkerStatus, error) {
 func (h *handler) Run(cmd *worker.RunCommand) (*worker.RunStatus, error) {
 	defer h.stat.Latency("runLatency_ms").Time().Stop()
 	h.stat.Counter("runs").Inc(1)
-	log.Printf("Worker Running:%s", cmd)
+	log.Info("Worker Running:%s", cmd)
 
 	h.updateTimeLastRpc()
 	c := domain.ThriftRunCommandToDomain(cmd)

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -3,7 +3,7 @@
 package server
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 	"sync"
 	"time"
 

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -105,7 +105,7 @@ func (h *handler) QueryWorker() (*worker.WorkerStatus, error) {
 func (h *handler) Run(cmd *worker.RunCommand) (*worker.RunStatus, error) {
 	defer h.stat.Latency("runLatency_ms").Time().Stop()
 	h.stat.Counter("runs").Inc(1)
-	log.Info("Worker Running:%s", cmd)
+	log.Debug("Worker Running:%s", cmd)
 
 	h.updateTimeLastRpc()
 	c := domain.ThriftRunCommandToDomain(cmd)

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -105,7 +105,7 @@ func (h *handler) QueryWorker() (*worker.WorkerStatus, error) {
 func (h *handler) Run(cmd *worker.RunCommand) (*worker.RunStatus, error) {
 	defer h.stat.Latency("runLatency_ms").Time().Stop()
 	h.stat.Counter("runs").Inc(1)
-	log.Debug("Worker Running:%s", cmd)
+	log.Info("Worker Running:%s", cmd)
 
 	h.updateTimeLastRpc()
 	c := domain.ThriftRunCommandToDomain(cmd)

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	log "github.com/scootdev/scoot/common/logger"
+	"github.com/scootdev/scoot/common/log"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/endpoints"

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"log"
+	log "github.com/inconshreveable/log15"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/endpoints"
@@ -68,11 +68,11 @@ func RunServer(
 	schema jsonconfig.Schema,
 	config []byte) {
 
-	log.Println("workerapi/server RunServer(), config is:", string(config))
+	log.Info("workerapi/server RunServer(), config is:", string(config))
 	// Parse Config
 	mod, err := schema.Parse(config)
 	if err != nil {
-		log.Fatal("Error configuring Worker: ", err)
+		log.Crit("Error configuring Worker: ", err)
 	}
 
 	// Initialize Objects Based on Config Settings
@@ -81,7 +81,7 @@ func RunServer(
 	var servers servers
 	err = bag.Extract(&servers)
 	if err != nil {
-		log.Fatal("Error injecting servers", err)
+		log.Crit("Error injecting servers", err)
 	}
 
 	errCh := make(chan error)
@@ -91,5 +91,5 @@ func RunServer(
 	go func() {
 		errCh <- servers.thrift.Serve()
 	}()
-	log.Fatal("Error serving: ", <-errCh)
+	log.Crit("Error serving: ", <-errCh)
 }

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	log "github.com/inconshreveable/log15"
+	log "github.com/scootdev/scoot/common/logger"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/scootdev/scoot/common/endpoints"

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -68,7 +68,7 @@ func RunServer(
 	schema jsonconfig.Schema,
 	config []byte) {
 
-	log.Debug("workerapi/server RunServer(), config is:", string(config))
+	log.Info("workerapi/server RunServer(), config is:", string(config))
 	// Parse Config
 	mod, err := schema.Parse(config)
 	if err != nil {

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -68,7 +68,7 @@ func RunServer(
 	schema jsonconfig.Schema,
 	config []byte) {
 
-	log.Info("workerapi/server RunServer(), config is:", string(config))
+	log.Debug("workerapi/server RunServer(), config is:", string(config))
 	// Parse Config
 	mod, err := schema.Parse(config)
 	if err != nil {


### PR DESCRIPTION
This replaces the stdlib logging we have used up to this point with a wrapper for github.com/inconshreveable/log15 as described within their godoc (https://godoc.org/github.com/inconshreveable/log15#hdr-Library_Use).

log15 has 5 levels we can use, Debug, Info, Warn, Error, Crit. 

I'm of the opinion that we only really need Crit for fatal errors, Info, for user facing log statements, and Debug for logs that we, as developers, care about, but I'm open to extending our API if we feel that we would benefit from including the Warn and Error levels (https://dave.cheney.net/2015/11/05/lets-talk-about-logging).

I replaced all log.Print(f/ln) statements with log.Info, this is in all likelihood not an accurate representation of the appropriate level for all of the logging statements, but that will require a much more thorough pass through at a later point.