### PR TITLE
First pass at scheduler tracking worker init status.

### DIFF
--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -58,7 +58,7 @@ func main() {
 		log.Fatal("Cannot create OutputCreator: ", err)
 	}
 	filer := snapshots.MakeTempFiler(tempDir)
-	r := runners.NewQueueRunner(ex, filer, outputCreator, tmp, *qLen)
+	r := runners.NewQueueRunner(ex, filer, nil, outputCreator, tmp, *qLen)
 	h := server.NewHandler(r, filer, 50*time.Millisecond)
 	s, err := server.NewServer(h)
 	if err != nil {

--- a/config/scootconfig/scheduler_config_modules.go
+++ b/config/scootconfig/scheduler_config_modules.go
@@ -7,6 +7,10 @@ import (
 	"github.com/scootdev/scoot/sched/scheduler"
 )
 
+const DefaultRunnerRetryTimeout = 10 * time.Second // How long to keep retrying a runner req
+const DefaultRunnerRetryInterval = time.Second     // How long to sleep between runner req retries.
+const DefaultReadyFnBackoff = 5 * time.Second      // How long to wait between runner status queries to determine [init] status.
+
 // Parameters to configure the Stateful Scheduler
 // MaxRetriesPerTask - the number of times to retry a failing task before
 //                     marking it as completed.
@@ -37,5 +41,8 @@ func (c *StatefulSchedulerConfig) Create() scheduler.SchedulerConfig {
 		RecoverJobsOnStartup: c.RecoverJobsOnStartup,
 		DefaultTaskTimeout:   time.Duration(c.DefaultTaskTimeoutMs) * time.Millisecond,
 		RunnerOverhead:       time.Duration(c.RunnerOverheadMs) * time.Millisecond,
+		RunnerRetryTimeout:   DefaultRunnerRetryTimeout,
+		RunnerRetryInterval:  DefaultRunnerRetryInterval,
+		ReadyFnBackoff:       DefaultReadyFnBackoff,
 	}
 }

--- a/daemon/server/handler.go
+++ b/daemon/server/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) Poll(runIds []runner.RunID, timeout time.Duration, returnAll b
 		completed := false
 		statuses = nil
 		for _, runId := range runIds {
-			status, _ := h.runner.Status(runId)
+			status, _, _ := h.runner.Status(runId)
 			if status.State.IsDone() {
 				completed = true
 			}

--- a/daemon/server/handler_test.go
+++ b/daemon/server/handler_test.go
@@ -24,7 +24,7 @@ func TestDaemonExample(t *testing.T) {
 	out, _ := runners.NewHttpOutputCreator(localTmp, "")
 	filer := snapshots.MakeTempFiler(filerTmp)
 	ex := execer.NewExecer()
-	run := runners.NewSingleRunner(ex, filer, out, filerTmp)
+	run := runners.NewSingleRunner(ex, filer, nil, out, filerTmp)
 	handler := NewHandler(run, filer, 50*time.Millisecond)
 
 	// Populate the paths we want to ingest.

--- a/runner/mocks/runner.go
+++ b/runner/mocks/runner.go
@@ -50,22 +50,24 @@ func (_mr *_MockServiceRecorder) Erase(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Erase", arg0)
 }
 
-func (_m *MockService) Query(_param0 runner.Query, _param1 runner.Wait) ([]runner.RunStatus, error) {
+func (_m *MockService) Query(_param0 runner.Query, _param1 runner.Wait) ([]runner.RunStatus, runner.ServiceStatus, error) {
 	ret := _m.ctrl.Call(_m, "Query", _param0, _param1)
 	ret0, _ := ret[0].([]runner.RunStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(runner.ServiceStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockServiceRecorder) Query(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Query", arg0, arg1)
 }
 
-func (_m *MockService) QueryNow(_param0 runner.Query) ([]runner.RunStatus, error) {
+func (_m *MockService) QueryNow(_param0 runner.Query) ([]runner.RunStatus, runner.ServiceStatus, error) {
 	ret := _m.ctrl.Call(_m, "QueryNow", _param0)
 	ret0, _ := ret[0].([]runner.RunStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(runner.ServiceStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockServiceRecorder) QueryNow(arg0 interface{}) *gomock.Call {
@@ -83,22 +85,24 @@ func (_mr *_MockServiceRecorder) Run(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Run", arg0)
 }
 
-func (_m *MockService) Status(_param0 runner.RunID) (runner.RunStatus, error) {
+func (_m *MockService) Status(_param0 runner.RunID) (runner.RunStatus, runner.ServiceStatus, error) {
 	ret := _m.ctrl.Call(_m, "Status", _param0)
 	ret0, _ := ret[0].(runner.RunStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(runner.ServiceStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockServiceRecorder) Status(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status", arg0)
 }
 
-func (_m *MockService) StatusAll() ([]runner.RunStatus, error) {
+func (_m *MockService) StatusAll() ([]runner.RunStatus, runner.ServiceStatus, error) {
 	ret := _m.ctrl.Call(_m, "StatusAll")
 	ret0, _ := ret[0].([]runner.RunStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(runner.ServiceStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockServiceRecorder) StatusAll() *gomock.Call {

--- a/runner/queries.go
+++ b/runner/queries.go
@@ -12,32 +12,32 @@ func WaitForever() Wait {
 }
 
 // Status returns the current status of id from q.
-func StatusNow(q StatusQueryNower, id RunID) (RunStatus, error) {
-	statuses, err := q.QueryNow(Query{Runs: []RunID{id}, States: ALL_MASK})
+func StatusNow(q StatusQueryNower, id RunID) (RunStatus, ServiceStatus, error) {
+	statuses, service, err := q.QueryNow(Query{Runs: []RunID{id}, States: ALL_MASK})
 	if err != nil {
-		return RunStatus{}, err
+		return RunStatus{}, ServiceStatus{}, err
 	}
-	return statuses[0], nil
+	return statuses[0], service, nil
 }
 
-func FinalStatus(q StatusQuerier, id RunID) (RunStatus, error) {
-	statuses, err := q.Query(Query{Runs: []RunID{id}, States: DONE_MASK}, WaitForever())
-	return SingleStatus(statuses, err)
+func FinalStatus(q StatusQuerier, id RunID) (RunStatus, ServiceStatus, error) {
+	statuses, service, err := q.Query(Query{Runs: []RunID{id}, States: DONE_MASK}, WaitForever())
+	return SingleStatus(statuses, service, err)
 }
 
-func WaitForState(q StatusQuerier, id RunID, expected RunState) (RunStatus, error) {
-	statuses, err := q.Query(Query{Runs: []RunID{id}, States: MaskForState(expected)}, WaitForever())
-	return SingleStatus(statuses, err)
+func WaitForState(q StatusQuerier, id RunID, expected RunState) (RunStatus, ServiceStatus, error) {
+	statuses, service, err := q.Query(Query{Runs: []RunID{id}, States: MaskForState(expected)}, WaitForever())
+	return SingleStatus(statuses, service, err)
 }
 
-func SingleStatus(statuses []RunStatus, err error) (RunStatus, error) {
+func SingleStatus(statuses []RunStatus, service ServiceStatus, err error) (RunStatus, ServiceStatus, error) {
 	if err != nil {
-		return RunStatus{}, err
+		return RunStatus{}, service, err
 	}
-	return statuses[0], nil
+	return statuses[0], service, nil
 }
 
 // StatusAll returns the Current status of all runs
-func StatusAll(q StatusQueryNower) ([]RunStatus, error) {
+func StatusAll(q StatusQueryNower) ([]RunStatus, ServiceStatus, error) {
 	return q.QueryNow(Query{States: ALL_MASK, AllRuns: true})
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,9 +17,6 @@ const NoRunnersMsg = "No runners available."
 const RunnerBusyMsg = "Runner is busy"
 const LoggingErrMsg = "Error initializing logging."
 
-// May be used to indicate if and when a Service instance is initialized.
-type InitCh <-chan struct{}
-
 // A command, execution environment, and timeout.
 type Command struct {
 	// Command line to run

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,6 +17,9 @@ const NoRunnersMsg = "No runners available."
 const RunnerBusyMsg = "Runner is busy"
 const LoggingErrMsg = "Error initializing logging."
 
+// May be used to indicate if and when a Service instance is initialized.
+type InitCh <-chan struct{}
+
 // A command, execution environment, and timeout.
 type Command struct {
 	// Command line to run

--- a/runner/runners/chaos.go
+++ b/runner/runners/chaos.go
@@ -60,34 +60,34 @@ func (r *ChaosRunner) Run(cmd *runner.Command) (runner.RunStatus, error) {
 	return r.del.Run(cmd)
 }
 
-func (r *ChaosRunner) Query(q runner.Query, w runner.Wait) ([]runner.RunStatus, error) {
+func (r *ChaosRunner) Query(q runner.Query, w runner.Wait) ([]runner.RunStatus, runner.ServiceStatus, error) {
 	err := r.delay()
 	if err != nil {
-		return nil, err
+		return nil, runner.ServiceStatus{}, err
 	}
 	return r.del.Query(q, w)
 }
 
-func (r *ChaosRunner) QueryNow(q runner.Query) ([]runner.RunStatus, error) {
+func (r *ChaosRunner) QueryNow(q runner.Query) ([]runner.RunStatus, runner.ServiceStatus, error) {
 	err := r.delay()
 	if err != nil {
-		return nil, err
+		return nil, runner.ServiceStatus{}, err
 	}
 	return r.del.QueryNow(q)
 }
 
-func (r *ChaosRunner) Status(run runner.RunID) (runner.RunStatus, error) {
+func (r *ChaosRunner) Status(run runner.RunID) (runner.RunStatus, runner.ServiceStatus, error) {
 	err := r.delay()
 	if err != nil {
-		return runner.RunStatus{}, err
+		return runner.RunStatus{}, runner.ServiceStatus{}, err
 	}
 	return r.del.Status(run)
 }
 
-func (r *ChaosRunner) StatusAll() ([]runner.RunStatus, error) {
+func (r *ChaosRunner) StatusAll() ([]runner.RunStatus, runner.ServiceStatus, error) {
 	err := r.delay()
 	if err != nil {
-		return nil, err
+		return nil, runner.ServiceStatus{}, err
 	}
 	return r.del.StatusAll()
 }

--- a/runner/runners/polling_test.go
+++ b/runner/runners/polling_test.go
@@ -14,7 +14,7 @@ import (
 func setupPoller() (*execers.SimExecer, *ChaosRunner, runner.Service) {
 	tmp, _ := temp.NewTempDir("", "runner_polling_test")
 	ex := execers.NewSimExecer()
-	single := NewSingleRunner(ex, snapshots.MakeInvalidFiler(), NewNullOutputCreator(), tmp)
+	single := NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, NewNullOutputCreator(), tmp)
 	chaos := NewChaosRunner(single)
 	var nower runner.StatusQueryNower
 	nower = chaos
@@ -29,7 +29,7 @@ func TestPollingWorker_Simple(t *testing.T) {
 	if err != nil {
 		t.Fatal(st, err)
 	}
-	st, err = runner.FinalStatus(poller, st.RunID)
+	st, _, err = runner.FinalStatus(poller, st.RunID)
 	if err != nil {
 		t.Fatal(st, err)
 	}
@@ -48,7 +48,7 @@ func TestPollingWorker_Wait(t *testing.T) {
 	}
 
 	go func() {
-		st, err := runner.FinalStatus(poller, st.RunID)
+		st, _, err := runner.FinalStatus(poller, st.RunID)
 		stCh <- st
 		errCh <- err
 	}()
@@ -80,7 +80,7 @@ func TestPollingWorker_Timeout(t *testing.T) {
 	}
 
 	go func() {
-		st, err := runner.FinalStatus(poller, st.RunID)
+		st, _, err := runner.FinalStatus(poller, st.RunID)
 		stCh <- st
 		errCh <- err
 	}()
@@ -120,7 +120,7 @@ func TestPolling_ErrorPolling(t *testing.T) {
 	}
 
 	go func() {
-		st, err := runner.FinalStatus(poller, st.RunID)
+		st, _, err := runner.FinalStatus(poller, st.RunID)
 		stCh <- st
 		errCh <- err
 	}()

--- a/runner/runners/queue_test.go
+++ b/runner/runners/queue_test.go
@@ -79,7 +79,7 @@ func TestUnknownRunIDInStatusRequest(t *testing.T) {
 	env := setup(4, t)
 	defer env.teardown()
 
-	st, err := env.r.Status(runner.RunID("not a real run id"))
+	st, _, err := env.r.Status(runner.RunID("not a real run id"))
 	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf(UnknownRunIDMsg, "")) {
 		t.Fatalf("Should not be able to get status: %q %q", err, st)
 	}
@@ -125,7 +125,7 @@ func TestStatus(t *testing.T) {
 	run7 := assertRun(t, env.r, pending(), "complete 0")
 	run8 := assertRun(t, env.r, pending(), "complete 0")
 
-	all, err := env.r.StatusAll()
+	all, _, err := env.r.StatusAll()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestStatus(t *testing.T) {
 	// We've already waited for each status to be correct, so we trust that.
 	// So, for each status in StatusAll, we'll call Status on its ID and error if not equal
 	for _, st := range all {
-		st2, err := env.r.Status(st.RunID)
+		st2, _, err := env.r.Status(st.RunID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -160,7 +160,7 @@ func setup(capacity int, t *testing.T) *env {
 	if err != nil {
 		t.Fatalf("Test setup() failed getting output creator:%s", err.Error())
 	}
-	r := NewQueueRunner(sim, snapshots.MakeInvalidFiler(), outputCreator, tmpDir, capacity)
+	r := NewQueueRunner(sim, snapshots.MakeInvalidFiler(), nil, outputCreator, tmpDir, capacity)
 
 	return &env{sim: sim, r: r}
 }

--- a/runner/runners/service_test.go
+++ b/runner/runners/service_test.go
@@ -47,7 +47,7 @@ func assertRun(t *testing.T, r runner.Service, expected runner.RunStatus, args .
 }
 
 func assertWait(t *testing.T, r runner.Service, runId runner.RunID, expected runner.RunStatus, args ...string) {
-	actual := wait(r, runId, expected)
+	actual, _ := wait(r, runId, expected)
 	assertStatus(t, actual, expected, args...)
 }
 
@@ -80,10 +80,10 @@ func run(t *testing.T, r runner.Service, args []string) runner.RunID {
 	return status.RunID
 }
 
-func wait(r runner.Service, run runner.RunID, expected runner.RunStatus) runner.RunStatus {
-	st, err := runner.WaitForState(r, run, expected.State)
+func wait(r runner.Service, run runner.RunID, expected runner.RunStatus) (runner.RunStatus, runner.ServiceStatus) {
+	st, svc, err := runner.WaitForState(r, run, expected.State)
 	if err != nil {
 		panic(err)
 	}
-	return st
+	return st, svc
 }

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -22,6 +22,7 @@ func NewStatusManager() *StatusManager {
 type StatusManager struct {
 	mu        sync.Mutex
 	runs      map[runner.RunID]runner.RunStatus
+	service   runner.ServiceStatus
 	nextRunID int64
 	listeners []queryAndCh
 }
@@ -49,6 +50,15 @@ func (s *StatusManager) NewRun() (runner.RunStatus, error) {
 	return st, nil
 }
 
+// Update the overall service status independent of run status.
+func (s *StatusManager) UpdateService(service runner.ServiceStatus) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.service = service
+	return nil
+}
+
 // Update writes a new status.
 // It enforces several rules:
 //   cannot change a status once it is Done
@@ -56,6 +66,7 @@ func (s *StatusManager) NewRun() (runner.RunStatus, error) {
 func (s *StatusManager) Update(newStatus runner.RunStatus) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	oldStatus, ok := s.runs[newStatus.RunID]
 	if ok && oldStatus.State.IsDone() {
 		return nil
@@ -87,11 +98,11 @@ func (s *StatusManager) Update(newStatus runner.RunStatus) error {
 
 // Reader interface (implements runner.StatusQuerier)
 
-// Query returns all RunStatus'es matching q, waiting as described by w
-func (s *StatusManager) Query(q runner.Query, wait runner.Wait) ([]runner.RunStatus, error) {
+// Query returns all RunStatus'es matching q, waiting as described by w, plus the overall service status.
+func (s *StatusManager) Query(q runner.Query, wait runner.Wait) ([]runner.RunStatus, runner.ServiceStatus, error) {
 	current, future, err := s.queryAndListen(q, wait.Timeout != 0)
 	if err != nil || len(current) > 0 || wait.Timeout == 0 {
-		return current, err
+		return current, s.service, err
 	}
 
 	var timeout <-chan time.Time
@@ -103,24 +114,24 @@ func (s *StatusManager) Query(q runner.Query, wait runner.Wait) ([]runner.RunSta
 
 	select {
 	case st := <-future:
-		return []runner.RunStatus{st}, nil
+		return []runner.RunStatus{st}, s.service, nil
 	case <-timeout:
-		return nil, nil
+		return nil, s.service, nil
 	}
 }
 
 // QueryNow returns all RunStatus'es matching q in their current state
-func (s *StatusManager) QueryNow(q runner.Query) ([]runner.RunStatus, error) {
+func (s *StatusManager) QueryNow(q runner.Query) ([]runner.RunStatus, runner.ServiceStatus, error) {
 	return s.Query(q, runner.Wait{})
 }
 
 // Status returns the current status of id from q.
-func (s *StatusManager) Status(id runner.RunID) (runner.RunStatus, error) {
+func (s *StatusManager) Status(id runner.RunID) (runner.RunStatus, runner.ServiceStatus, error) {
 	return runner.StatusNow(s, id)
 }
 
 // StatusAll returns the Current status of all runs
-func (s *StatusManager) StatusAll() ([]runner.RunStatus, error) {
+func (s *StatusManager) StatusAll() ([]runner.RunStatus, runner.ServiceStatus, error) {
 	return runner.StatusAll(s)
 }
 
@@ -140,7 +151,8 @@ func (s *StatusManager) Erase(run runner.RunID) error {
 //   the current results
 //   a channel that will hold the next result (if current is empty and err is nil)
 //   error
-func (s *StatusManager) queryAndListen(q runner.Query, listen bool) (current []runner.RunStatus, future chan runner.RunStatus, err error) {
+func (s *StatusManager) queryAndListen(q runner.Query, listen bool) (
+	current []runner.RunStatus, future chan runner.RunStatus, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/runner/status.go
+++ b/runner/status.go
@@ -151,3 +151,12 @@ func PreparingStatus(runID RunID) (r RunStatus) {
 	r.State = PREPARING
 	return r
 }
+
+// This is for overall runner status, just 'initialized' status for now.
+type ServiceStatus struct {
+	Initialized bool
+}
+
+func (s ServiceStatus) String() string {
+	return fmt.Sprintf("--- Service Status ---\n\tInitialized:%t\n", s.Initialized)
+}

--- a/runner/status_rw.go
+++ b/runner/status_rw.go
@@ -55,7 +55,7 @@ type Wait struct {
 // StatusQuerier allows reading Status by Query'ing.
 type StatusQuerier interface {
 	// Query returns all RunStatus'es matching q, waiting as described by w
-	Query(q Query, w Wait) ([]RunStatus, error)
+	Query(q Query, w Wait) ([]RunStatus, ServiceStatus, error)
 
 	StatusQueryNower
 }
@@ -68,17 +68,17 @@ type StatusQuerier interface {
 // We will implement a PollingQueuer that wraps a StatusQueryNower and satisfies StatusQuerier.
 type StatusQueryNower interface {
 	// QueryNow returns all RunStatus'es matching q in their current state
-	QueryNow(q Query) ([]RunStatus, error)
+	QueryNow(q Query) ([]RunStatus, ServiceStatus, error)
 }
 
 // LegacyStatusReader contains legacy methods to read Status'es.
 // Prefer using the convenience methods above.
 type LegacyStatusReader interface {
 	// Status returns the current status of id from q.
-	Status(run RunID) (RunStatus, error)
+	Status(run RunID) (RunStatus, ServiceStatus, error)
 
 	// StatusAll returns the Current status of all runs
-	StatusAll() ([]RunStatus, error)
+	StatusAll() ([]RunStatus, ServiceStatus, error)
 }
 
 // StatusReader includes both the preferred and the legacy api.
@@ -94,8 +94,11 @@ type StatusWriter interface {
 	// NewRun creates a new RunID in state Preparing
 	NewRun() (RunStatus, error)
 
+	// Update overall service status.
+	UpdateService(st ServiceStatus) error
+
 	// Update writes a new status.
-	UpdateStatus(st RunStatus) error
+	Update(st RunStatus) error
 
 	StatusEraser
 }

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -11,8 +11,11 @@ import (
 const noTask = ""
 const defaultMaxLostDuration = time.Minute
 const defaultMaxFlakyDuration = time.Minute
+const defaultReadyFnInterval = 5 * time.Second
 
 var nilTime = time.Time{}
+
+type ReadyFn func(cluster.Node) bool
 
 // clusterState maintains a cluster of nodes and information about what task is running on each node.
 // nodeGroups is for node affinity where we want to remember which node last ran with what snapshot.
@@ -20,10 +23,12 @@ var nilTime = time.Time{}
 type clusterState struct {
 	updateCh         chan []cluster.NodeUpdate
 	nodes            map[cluster.NodeId]*nodeState // All healthy nodes.
-	suspendedNodes   map[cluster.NodeId]*nodeState // All lost or flaky nodes, disjoint from 'nodes'.
-	nodeGroups       map[string]*nodeGroup         //key is a snapshotId.
+	suspendedNodes   map[cluster.NodeId]*nodeState // All new, lost, or flaky nodes, disjoint from 'nodes'.
+	nodeGroups       map[string]*nodeGroup         // key is a snapshotId.
 	maxLostDuration  time.Duration                 // after which we remove a node from the cluster entirely
 	maxFlakyDuration time.Duration                 // after which we mark it not flaky and put it back in rotation.
+	readyFnInterval  time.Duration                 // how often we should call readyFn to validate node.
+	readyFn          ReadyFn                       // If provided, new nodes will be suspended until this returns true.
 }
 
 type nodeGroup struct {
@@ -40,14 +45,15 @@ type nodeState struct {
 	node        cluster.Node
 	runningTask string
 	snapshotId  string
-	timeLost    time.Time // Time when node was marked lost, if set.
-	timeFlaky   time.Time // Time when node was marked flaky, if set.
+	timeInit    time.Time // Time when new node was marked init'ing. Unset once init completes.
+	timeLost    time.Time // Time when node was marked lost, if set (lost and flaky are mutually exclusive).
+	timeFlaky   time.Time // Time when node was marked flaky, if set (lost and flaky are mutually exclusive).
 }
 
 // This node was either reported lost by a NodeUpdate and we keep it around for a bit in case it revives,
 // or it experienced connection related errors so we sideline it for a little while.
 func (ns *nodeState) suspended() bool {
-	return ns.timeLost != nilTime || ns.timeFlaky != nilTime
+	return ns.timeInit != nilTime || ns.timeLost != nilTime || ns.timeFlaky != nilTime
 }
 
 // Initializes a Node State for the specified Node
@@ -56,14 +62,15 @@ func newNodeState(node cluster.Node) *nodeState {
 		node:        node,
 		runningTask: noTask,
 		snapshotId:  "",
+		timeInit:    nilTime,
 		timeLost:    nilTime,
 		timeFlaky:   nilTime,
 	}
 }
 
 // Creates a New State Distributor with the initial nodes, and which updates
-// nodes added or removed based on the supplied channel.
-func newClusterState(initial []cluster.Node, updateCh chan []cluster.NodeUpdate) *clusterState {
+// nodes added or removed based on the supplied channel. ReadyFn is optional.
+func newClusterState(initial []cluster.Node, updateCh chan []cluster.NodeUpdate, rfn ReadyFn) *clusterState {
 	nodes := make(map[cluster.NodeId]*nodeState)
 	nodeGroups := map[string]*nodeGroup{"": newNodeGroup()}
 	for _, n := range initial {
@@ -78,6 +85,8 @@ func newClusterState(initial []cluster.Node, updateCh chan []cluster.NodeUpdate)
 		nodeGroups:       nodeGroups,
 		maxLostDuration:  defaultMaxLostDuration,
 		maxFlakyDuration: defaultMaxFlakyDuration,
+		readyFnInterval:  defaultReadyFnInterval,
+		readyFn:          rfn,
 	}
 }
 
@@ -137,40 +146,61 @@ func (c *clusterState) updateCluster() {
 
 // Processes nodes being added and removed from the cluster & updates the distributor state accordingly.
 // Note, we don't expect there to be many updates after startup if the cluster is relatively stable.
+//TODO(jschiller) this assumes that new nodes never have the same id as previous ones but we can't rely on that.
 func (c *clusterState) update(updates []cluster.NodeUpdate) {
 	// Apply updates
 	for _, update := range updates {
 		switch update.UpdateType {
 		case cluster.NodeAdded:
 			if ns, ok := c.suspendedNodes[update.Id]; ok {
-				// This node was suspended earlier (assuming id is unique to a running node instance), we can recover it now.
-				ns.timeLost = nilTime
-				c.nodes[update.Id] = ns
-				delete(c.suspendedNodes, update.Id)
-				log.Infof("Recovered suspended node %v (%v), now have %d healthy nodes, %d suspended nodes",
-					update.Id, ns, len(c.nodes), len(c.suspendedNodes))
+				if ns.timeInit != nilTime {
+					// Adding a node that's already suspended as non-ready, leave it in that state until ready.
+					log.Infof("Suspended node re-added but still awaiting readiness check %v (%#v)", update.Id, ns)
+				} else {
+					// This node was suspended earlier, we can recover it now.
+					ns.timeLost = nilTime
+					ns.timeFlaky = nilTime
+					c.nodes[update.Id] = ns
+					delete(c.suspendedNodes, update.Id)
+					log.Infof("Recovered suspended node %v (%#v), now have %d healthy nodes (%d suspended)",
+						update.Id, ns, len(c.nodes), len(c.suspendedNodes))
+				}
+
 			} else if ns, ok := c.nodes[update.Id]; !ok {
-				// This is a new unrecognized node, add it to the cluster.
-				c.nodes[update.Id] = newNodeState(update.Node)
+				// This is a new unrecognized node, add it to the cluster, possibly in a suspended state.
+				if c.readyFn == nil || c.readyFn(ns.node) {
+					// We're either not checking readiness or it is ready, skip suspended state and add this as a healthy node.
+					c.nodes[update.Id] = newNodeState(update.Node)
+					log.Infof("Added new node: %v (%#v), now have %d healthy nodes (%d suspended)",
+						update.Id, update.Node, len(c.nodes), len(c.suspendedNodes))
+				} else {
+					// Add this to the suspended nodes to be checked on every update().
+					c.suspendedNodes[update.Id] = newNodeState(update.Node)
+					c.suspendedNodes[update.Id].timeInit = time.Now()
+					log.Infof("Added new suspended node: %v (%#v), now have %d healthy nodes (%d suspended)",
+						update.Id, update.Node, len(c.nodes), len(c.suspendedNodes))
+				}
 				c.nodeGroups[""].idle[update.Id] = c.nodes[update.Id]
-				log.Infof("Added new node: %v (%+v), now have %d nodes", update.Id, update.Node, len(c.nodes))
+
 			} else {
 				// This node is already present, log this spurious add.
-				log.Infof("Node already added!! %v (%v)", update.Id, ns)
+				log.Infof("Node already added!! %v (%#v)", update.Id, ns)
 			}
 		case cluster.NodeRemoved:
 			if ns, ok := c.suspendedNodes[update.Id]; ok {
-				// Node already suspended, make sure it's now marked as lost and not flaky.
-				log.Infof("Node already marked suspended (was flaky=%t) : %v (%v)", ns.timeFlaky != nilTime, update.Id, ns)
+				// Node already suspended, make sure it's now marked as lost and not flaky (keep readiness status intact).
+				log.Infof("Already suspended node marked as removed: %v (was %#v)", update.Id, ns)
 				ns.timeLost = time.Now()
 				ns.timeFlaky = nilTime
+
 			} else if ns, ok := c.nodes[update.Id]; ok {
 				// This was a healthy node, mark it as lost now.
 				ns.timeLost = time.Now()
 				c.suspendedNodes[update.Id] = ns
 				delete(c.nodes, update.Id)
-				log.Infof("Removing node by marking as lost: %v (%v), now have %d nodes, %d suspended",
+				log.Infof("Removing node by marking as lost: %v (%#v), now have %d nodes (%d suspended)",
 					update.Id, ns, len(c.nodes), len(c.suspendedNodes))
+
 			} else {
 				// We don't know about this node, log spurious remove.
 				log.Infof("Cannot remove unknown node: %v", update.Id)
@@ -178,21 +208,33 @@ func (c *clusterState) update(updates []cluster.NodeUpdate) {
 		}
 	}
 
-	// Clean up lost nodes that haven't recovered in time, and put flaky nodes back in rotation.
+	// Clean up lost nodes that haven't recovered in time, add flaky nodes back into rotation after some time,
+	// and check if newly added non-ready nodes are ready to be put into rotation.
 	now := time.Now()
 	for _, ns := range c.suspendedNodes {
 		if ns.timeLost != nilTime && now.Sub(ns.timeLost) > c.maxLostDuration {
-			log.Infof("Deleting lost node: %v (%v), now have %d healthy, %d suspended",
+			log.Infof("Deleting lost node: %v (%#v), now have %d healthy (%d suspended)",
 				ns.node.Id(), ns, len(c.nodes), len(c.suspendedNodes)-1)
 			delete(c.suspendedNodes, ns.node.Id())
 			delete(c.nodeGroups[ns.snapshotId].idle, ns.node.Id())
 			delete(c.nodeGroups[ns.snapshotId].busy, ns.node.Id())
+
 		} else if ns.timeFlaky != nilTime && now.Sub(ns.timeFlaky) > c.maxFlakyDuration {
-			log.Infof("Reinstating flaky node: %v (%v), now have %d healthy, %d suspended",
+			log.Infof("Reinstating flaky node: %v (%#v), now have %d healthy (%d suspended)",
 				ns.node.Id(), ns, len(c.nodes), len(c.suspendedNodes))
 			delete(c.suspendedNodes, ns.node.Id())
 			c.nodes[ns.node.Id()] = ns
 			ns.timeFlaky = nilTime
+
+		} else if ns.timeInit != nilTime && now.Sub(ns.timeInit) > c.readyFnInterval {
+			if c.readyFn(ns.node) {
+				log.Infof("Node now ready, adding to rotation: %v (%#v), now have %d healthy (%d suspended)",
+					ns.node.Id(), ns, len(c.nodes), len(c.suspendedNodes))
+				c.nodes[ns.node.Id()] = ns
+				ns.timeInit = nilTime
+			} else {
+				ns.timeInit = now
+			}
 		}
 	}
 }

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -109,12 +109,8 @@ func NewStatefulScheduler(
 
 	nodeReadyFn := func(node cluster.Node) bool {
 		run := rf(node)
-		st, err := run.StatusAll()
-		if err != nil {
-			return false
-		}
-		if len(st) == 1 && st[0].Error == runner.NoRunnersMsg {
-			//TODO(jschiller) amend protocol to be more direct than this array of one with a particular error status.
+		st, svc, err := run.StatusAll()
+		if err != nil || !svc.Initialized {
 			return false
 		}
 		for _, s := range st {

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -215,7 +215,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 	deps.rf = func(cluster.Node) runner.Service {
 		ex := execers.NewDoneExecer()
 		ex.State = execer.FAILED
-		return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), runners.NewNullOutputCreator(), tmp)
+		return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
 	}
 
 	s := makeStatefulSchedulerDeps(deps)

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -165,7 +165,7 @@ func (r *taskRunner) queryWithTimeout(id runner.RunID, endTime time.Time, includ
 		timeout = 0
 	}
 	w := runner.Wait{Timeout: timeout}
-	sts, err := r.runner.Query(q, w)
+	sts, _, err := r.runner.Query(q, w)
 	if err != nil {
 		return runner.RunStatus{}, err
 	}

--- a/sched/scheduler/task_runner_test.go
+++ b/sched/scheduler/task_runner_test.go
@@ -259,7 +259,8 @@ func Test_runTaskWithQueryRetry(t *testing.T) {
 	runMock := runnermock.NewMockService(mockCtrl)
 	queryErr := errors.New("QueryErr")
 	runMock.EXPECT().Run(gomock.Any()).Return(runner.RunStatus{}, nil)
-	runMock.EXPECT().Query(gomock.Any(), gomock.Any()).Return([]runner.RunStatus{runner.RunStatus{}}, queryErr).Times(2)
+	runMock.EXPECT().Query(gomock.Any(), gomock.Any()).Return(
+		[]runner.RunStatus{runner.RunStatus{}}, runner.ServiceStatus{}, queryErr).Times(2)
 
 	tr := testTaskRunner(s, runMock, "task1", sched.GenTask(), true)
 	tr.runnerRetryTimeout = 3 * time.Millisecond

--- a/sched/scheduler/task_scheduler_test.go
+++ b/sched/scheduler/task_scheduler_test.go
@@ -21,7 +21,7 @@ func Test_TaskAssignment_NoNodesAvailable(t *testing.T) {
 
 	// create a test cluster with no nodes
 	testCluster := makeTestCluster()
-	cs := newClusterState(testCluster.nodes, testCluster.ch)
+	cs := newClusterState(testCluster.nodes, testCluster.ch, nil)
 	assignments, _ := getTaskAssignments(cs, jobState.getUnScheduledTasks())
 
 	if len(assignments) != 0 {
@@ -32,7 +32,7 @@ func Test_TaskAssignment_NoNodesAvailable(t *testing.T) {
 func Test_TaskAssignment_NoTasks(t *testing.T) {
 	// create a test cluster with no nodes
 	testCluster := makeTestCluster("node1", "node2", "node3", "node4", "node5")
-	cs := newClusterState(testCluster.nodes, testCluster.ch)
+	cs := newClusterState(testCluster.nodes, testCluster.ch, nil)
 	assignments, _ := getTaskAssignments(cs, []*taskState{})
 
 	if len(assignments) != 0 {
@@ -51,7 +51,7 @@ func Test_TaskAssignments_TasksScheduled(t *testing.T) {
 
 	// create a test cluster with no nodes
 	testCluster := makeTestCluster("node1", "node2", "node3", "node4", "node5")
-	cs := newClusterState(testCluster.nodes, testCluster.ch)
+	cs := newClusterState(testCluster.nodes, testCluster.ch, nil)
 	unScheduledTasks := jobState.getUnScheduledTasks()
 	assignments, _ := getTaskAssignments(cs, unScheduledTasks)
 
@@ -66,7 +66,7 @@ func Test_TaskAssignments_TasksScheduled(t *testing.T) {
 
 func Test_TaskAssignment_Affinity(t *testing.T) {
 	testCluster := makeTestCluster("node1", "node2", "node3")
-	cs := newClusterState(testCluster.nodes, testCluster.ch)
+	cs := newClusterState(testCluster.nodes, testCluster.ch, nil)
 	tasks := []*taskState{
 		&taskState{TaskId: "task1", Def: sched.TaskDefinition{Command: runner.Command{SnapshotID: "snapA"}}},
 		&taskState{TaskId: "task2", Def: sched.TaskDefinition{Command: runner.Command{SnapshotID: "snapA"}}},

--- a/sched/worker/workers/makers.go
+++ b/sched/worker/workers/makers.go
@@ -19,7 +19,7 @@ func MakeInmemoryWorker(node cluster.Node, tmp *temp.TempDir) runner.Service {
 // Makes a worker suitable for using as an in-memory worker.
 func MakeDoneWorker(tmp *temp.TempDir) runner.Service {
 	ex := execers.NewDoneExecer()
-	r := runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), runners.NewNullOutputCreator(), tmp)
+	r := runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
 	chaos := runners.NewChaosRunner(r)
 	chaos.SetDelay(time.Duration(500) * time.Millisecond)
 	return chaos
@@ -28,5 +28,5 @@ func MakeDoneWorker(tmp *temp.TempDir) runner.Service {
 // Makes a worker that uses a SimExecer. This is suitable for testing.
 func MakeSimWorker(tmp *temp.TempDir) runner.Service {
 	ex := execers.NewSimExecer()
-	return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), runners.NewNullOutputCreator(), tmp)
+	return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
 }

--- a/snapshot/db.go
+++ b/snapshot/db.go
@@ -7,6 +7,9 @@ import (
 // ID identifies a Snapshot in DB. (Cf. doc.go for explanation of Snapshot) Opaque to the client.
 type ID string
 
+// DB may require some form of initialization, in which case this chan should be provided by the db impl.
+type InitDoneCh <-chan struct{}
+
 // Creator allows creating new Snapshots.
 type Creator interface {
 	// Ingest

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -13,9 +13,6 @@ import (
 // kind instead of type because type is a keyword
 type snapshotKind string
 
-// Returned by MakeDBNewRepo(), gets closed as soon as the repo is initialized.
-type InitCh <-chan struct{}
-
 const (
 	kindFSSnapshot        snapshotKind = "fs"
 	kindGitCommitSnapshot snapshotKind = "gc"
@@ -43,12 +40,12 @@ func MakeDBFromRepo(dataRepo *repo.Repository, tmp *temp.TempDir, stream *Stream
 
 // MakeDBNewRepo makes a gitDB that uses a new DB, populated by initer
 func MakeDBNewRepo(initer RepoIniter, tmp *temp.TempDir, stream *StreamConfig,
-	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) (*DB, InitCh) {
+	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) (*DB, snap.InitDoneCh) {
 	return makeDB(nil, initer, tmp, stream, tags, bundles, autoUploadDest)
 }
 
 func makeDB(dataRepo *repo.Repository, initer RepoIniter, tmp *temp.TempDir, stream *StreamConfig,
-	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) (*DB, InitCh) {
+	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) (*DB, snap.InitDoneCh) {
 	if (dataRepo == nil) == (initer == nil) {
 		panic(fmt.Errorf("exactly one of dataRepo and initer must be non-nil in call to makeDB: %v %v", dataRepo, initer))
 	}

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -34,24 +34,23 @@ const (
 // MakeDBFromRepo makes a gitdb.DB that uses dataRepo for data and tmp for temporary directories
 func MakeDBFromRepo(dataRepo *repo.Repository, tmp *temp.TempDir, stream *StreamConfig,
 	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) *DB {
-	db, _ := makeDB(dataRepo, nil, tmp, stream, tags, bundles, autoUploadDest)
-	return db
+	return makeDB(dataRepo, nil, tmp, stream, tags, bundles, autoUploadDest)
 }
 
 // MakeDBNewRepo makes a gitDB that uses a new DB, populated by initer
 func MakeDBNewRepo(initer RepoIniter, tmp *temp.TempDir, stream *StreamConfig,
-	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) (*DB, snap.InitDoneCh) {
+	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) *DB {
 	return makeDB(nil, initer, tmp, stream, tags, bundles, autoUploadDest)
 }
 
 func makeDB(dataRepo *repo.Repository, initer RepoIniter, tmp *temp.TempDir, stream *StreamConfig,
-	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) (*DB, snap.InitDoneCh) {
+	tags *TagsConfig, bundles *BundlestoreConfig, autoUploadDest AutoUploadDest) *DB {
 	if (dataRepo == nil) == (initer == nil) {
 		panic(fmt.Errorf("exactly one of dataRepo and initer must be non-nil in call to makeDB: %v %v", dataRepo, initer))
 	}
 	result := &DB{
-		reqCh:      make(chan req),
 		initDoneCh: make(chan struct{}),
+		reqCh:      make(chan req),
 		dataRepo:   dataRepo,
 		tmp:        tmp,
 		checkouts:  make(map[string]bool),
@@ -72,7 +71,7 @@ func makeDB(dataRepo *repo.Repository, initer RepoIniter, tmp *temp.TempDir, str
 	}
 
 	go result.loop(initer)
-	return result, result.initDoneCh
+	return result
 }
 
 type RepoIniter interface {

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -3,12 +3,13 @@ package gitdb
 import (
 	"flag"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/scootdev/scoot/os/temp"
 	snap "github.com/scootdev/scoot/snapshot"
@@ -185,7 +186,7 @@ func TestInit(t *testing.T) {
 		RefSpec: "refs/remotes/ro/master",
 	}
 
-	db := MakeDBNewRepo(&bundleIniter{mirror, ro}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
+	db, _ := MakeDBNewRepo(&bundleIniter{mirror, ro}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
 	defer db.Close()
 
 	firstID := db.IDForStreamCommitSHA("sro", firstCommitID)
@@ -224,7 +225,7 @@ func TestInitFails(t *testing.T) {
 		RefSpec: "refs/remotes/ro/master",
 	}
 
-	db := MakeDBNewRepo(&bundleIniter{"/dev/null", fixture.upstream}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
+	db, _ := MakeDBNewRepo(&bundleIniter{"/dev/null", fixture.upstream}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
 	defer db.Close()
 
 	ingestDir, err := fixture.tmp.TempDir("ingest_dir")

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -186,7 +186,7 @@ func TestInit(t *testing.T) {
 		RefSpec: "refs/remotes/ro/master",
 	}
 
-	db, _ := MakeDBNewRepo(&bundleIniter{mirror, ro}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
+	db := MakeDBNewRepo(&bundleIniter{mirror, ro}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
 	defer db.Close()
 
 	firstID := db.IDForStreamCommitSHA("sro", firstCommitID)
@@ -225,7 +225,7 @@ func TestInitFails(t *testing.T) {
 		RefSpec: "refs/remotes/ro/master",
 	}
 
-	db, _ := MakeDBNewRepo(&bundleIniter{"/dev/null", fixture.upstream}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
+	db := MakeDBNewRepo(&bundleIniter{"/dev/null", fixture.upstream}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
 	defer db.Close()
 
 	ingestDir, err := fixture.tmp.TempDir("ingest_dir")

--- a/snapshot/git/gitdb/setup.go
+++ b/snapshot/git/gitdb/setup.go
@@ -3,7 +3,6 @@ package gitdb
 import (
 	"github.com/scootdev/scoot/ice"
 	"github.com/scootdev/scoot/os/temp"
-	"github.com/scootdev/scoot/runner"
 	snap "github.com/scootdev/scoot/snapshot"
 	"github.com/scootdev/scoot/snapshot/bundlestore"
 	"github.com/scootdev/scoot/snapshot/git/repo"
@@ -37,9 +36,6 @@ func (m module) Install(b *ice.MagicBag) {
 		MakeDBNewRepo,
 		func(db *DB) snap.DB {
 			return db
-		},
-		func(ic InitCh) runner.InitCh {
-			return runner.InitCh(ic)
 		},
 	)
 }

--- a/snapshot/git/gitdb/setup.go
+++ b/snapshot/git/gitdb/setup.go
@@ -37,6 +37,9 @@ func (m module) Install(b *ice.MagicBag) {
 		func(db *DB) snap.DB {
 			return db
 		},
+		func(db *DB) snap.InitDoneCh {
+			return db.initDoneCh
+		},
 	)
 }
 

--- a/snapshot/git/gitdb/setup.go
+++ b/snapshot/git/gitdb/setup.go
@@ -3,6 +3,7 @@ package gitdb
 import (
 	"github.com/scootdev/scoot/ice"
 	"github.com/scootdev/scoot/os/temp"
+	"github.com/scootdev/scoot/runner"
 	snap "github.com/scootdev/scoot/snapshot"
 	"github.com/scootdev/scoot/snapshot/bundlestore"
 	"github.com/scootdev/scoot/snapshot/git/repo"
@@ -34,7 +35,12 @@ func (m module) Install(b *ice.MagicBag) {
 			return AutoUploadBundlestore
 		},
 		MakeDBNewRepo,
-		func(db *DB) snap.DB { return db },
+		func(db *DB) snap.DB {
+			return db
+		},
+		func(ic InitCh) runner.InitCh {
+			return runner.InitCh(ic)
+		},
 	)
 }
 

--- a/workerapi/api.go
+++ b/workerapi/api.go
@@ -14,7 +14,9 @@ import (
 
 //TODO: test workerStatus.
 type WorkerStatus struct {
-	Runs []runner.RunStatus
+	Runs        []runner.RunStatus
+	Initialized bool
+	Error       string
 }
 
 func ThriftWorkerStatusToDomain(thrift *worker.WorkerStatus) WorkerStatus {
@@ -22,7 +24,7 @@ func ThriftWorkerStatusToDomain(thrift *worker.WorkerStatus) WorkerStatus {
 	for _, r := range thrift.Runs {
 		runs = append(runs, ThriftRunStatusToDomain(r))
 	}
-	return WorkerStatus{runs}
+	return WorkerStatus{runs, thrift.Initialized, thrift.Error}
 }
 
 func DomainWorkerStatusToThrift(domain WorkerStatus) *worker.WorkerStatus {
@@ -30,6 +32,8 @@ func DomainWorkerStatusToThrift(domain WorkerStatus) *worker.WorkerStatus {
 	thrift.Runs = make([]*worker.RunStatus, 0)
 	for _, r := range domain.Runs {
 		thrift.Runs = append(thrift.Runs, DomainRunStatusToThrift(r))
+		thrift.Initialized = domain.Initialized
+		thrift.Error = domain.Error
 	}
 	return thrift
 }

--- a/workerapi/gen-go/worker/ttypes.go
+++ b/workerapi/gen-go/worker/ttypes.go
@@ -458,8 +458,12 @@ func (p *RunStatus) String() string {
 
 // Attributes:
 //  - Runs
+//  - Initialized
+//  - Error
 type WorkerStatus struct {
-	Runs []*RunStatus `thrift:"runs,1,required" json:"runs"`
+	Runs        []*RunStatus `thrift:"runs,1,required" json:"runs"`
+	Initialized bool         `thrift:"initialized,2,required" json:"initialized"`
+	Error       string       `thrift:"error,3,required" json:"error"`
 }
 
 func NewWorkerStatus() *WorkerStatus {
@@ -469,12 +473,22 @@ func NewWorkerStatus() *WorkerStatus {
 func (p *WorkerStatus) GetRuns() []*RunStatus {
 	return p.Runs
 }
+
+func (p *WorkerStatus) GetInitialized() bool {
+	return p.Initialized
+}
+
+func (p *WorkerStatus) GetError() string {
+	return p.Error
+}
 func (p *WorkerStatus) Read(iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
 	}
 
 	var issetRuns bool = false
+	var issetInitialized bool = false
+	var issetError bool = false
 
 	for {
 		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
@@ -490,6 +504,16 @@ func (p *WorkerStatus) Read(iprot thrift.TProtocol) error {
 				return err
 			}
 			issetRuns = true
+		case 2:
+			if err := p.readField2(iprot); err != nil {
+				return err
+			}
+			issetInitialized = true
+		case 3:
+			if err := p.readField3(iprot); err != nil {
+				return err
+			}
+			issetError = true
 		default:
 			if err := iprot.Skip(fieldTypeId); err != nil {
 				return err
@@ -504,6 +528,12 @@ func (p *WorkerStatus) Read(iprot thrift.TProtocol) error {
 	}
 	if !issetRuns {
 		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Runs is not set"))
+	}
+	if !issetInitialized {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Initialized is not set"))
+	}
+	if !issetError {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Error is not set"))
 	}
 	return nil
 }
@@ -528,11 +558,35 @@ func (p *WorkerStatus) readField1(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *WorkerStatus) readField2(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 2: ", err)
+	} else {
+		p.Initialized = v
+	}
+	return nil
+}
+
+func (p *WorkerStatus) readField3(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(); err != nil {
+		return thrift.PrependError("error reading field 3: ", err)
+	} else {
+		p.Error = v
+	}
+	return nil
+}
+
 func (p *WorkerStatus) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("WorkerStatus"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
 	}
 	if err := p.writeField1(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField2(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField3(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -561,6 +615,32 @@ func (p *WorkerStatus) writeField1(oprot thrift.TProtocol) (err error) {
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:runs: ", p), err)
+	}
+	return err
+}
+
+func (p *WorkerStatus) writeField2(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("initialized", thrift.BOOL, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:initialized: ", p), err)
+	}
+	if err := oprot.WriteBool(bool(p.Initialized)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.initialized (2) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:initialized: ", p), err)
+	}
+	return err
+}
+
+func (p *WorkerStatus) writeField3(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("error", thrift.STRING, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:error: ", p), err)
+	}
+	if err := oprot.WriteString(string(p.Error)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.error (3) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:error: ", p), err)
 	}
 	return err
 }

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -46,8 +46,8 @@ func (m module) Install(b *ice.MagicBag) {
 		func(m execer.Memory, s stats.StatsReceiver) execer.Execer {
 			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(m, s))
 		},
-		func(stat stats.StatsReceiver, r runner.Service, ic runner.InitCh) worker.Worker {
-			return NewHandler(stat, r, ic)
+		func(stat stats.StatsReceiver, r runner.Service) worker.Worker {
+			return NewHandler(stat, r)
 		},
 		func(
 			handler worker.Worker,

--- a/workerapi/server/setup.go
+++ b/workerapi/server/setup.go
@@ -46,8 +46,8 @@ func (m module) Install(b *ice.MagicBag) {
 		func(m execer.Memory, s stats.StatsReceiver) execer.Execer {
 			return execers.MakeSimExecerInterceptor(execers.NewSimExecer(), osexec.NewBoundedExecer(m, s))
 		},
-		func(stat stats.StatsReceiver, r runner.Service) worker.Worker {
-			return NewHandler(stat, r)
+		func(stat stats.StatsReceiver, r runner.Service, ic runner.InitCh) worker.Worker {
+			return NewHandler(stat, r, ic)
 		},
 		func(
 			handler worker.Worker,

--- a/workerapi/worker.thrift
+++ b/workerapi/worker.thrift
@@ -23,6 +23,8 @@ struct RunStatus {
 // TODO: add useful load information when it comes time to have multiple runs.
 struct WorkerStatus {
   1: required list<RunStatus> runs  # All runs excepting what's been Erase()'d
+  2: required bool initialized      # True if the worker has finished with any long-running init tasks.
+  3: required string error          # Set when a general worker error unrelated to a specific run has occurred.
 }
 
 struct RunCommand {


### PR DESCRIPTION
Looking for feedback on this approach and any general suggestions. Tests to come later.

The basic idea here is that new nodes should be initially tracked as suspended nodes and moved to the healthy node pool once they've completely started up. This is mostly plumbing.