### PR TITLE
generate run success and failure summaries from a worker log

### DIFF
--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -114,7 +114,7 @@ func (h *handler) QueryWorker() (*worker.WorkerStatus, error) {
 	for _, status := range st {
 		if status.State.IsDone() {
 			// Note: TravisCI fails when output is too long so we set full status to Debug and disable it when running in that env.
-			log.Info("Worker returning finished run: %v", status.RunID)
+			log.Info("Worker returning finished run: %s", status.RunID)
 			log.Debugf("Worker returning finished run (details): %v", status)
 		}
 		ws.Runs = append(ws.Runs, domain.DomainRunStatusToThrift(status))


### PR DESCRIPTION
I used this to handle large (1.9M line) log files.  See https://confluence.twitter.biz/display/EE/Aurora+Developer+Environment#AuroraDeveloperEnvironment-Workerlog: for usage instructions.