### PR TITLE
runner/execer/os: Memory usage and cleanup of processes

### DIFF
--- a/runner/execer/os/easy_test.go
+++ b/runner/execer/os/easy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/runner/execer"
 )
 
@@ -66,6 +67,36 @@ func TestMemUsage(t *testing.T) {
 	str := `import time; exec("x=[]\nfor i in range(5):\n x.append(' ' * 10*1024*1024)\n time.sleep(.1)")`
 	cmd := execer.Command{Argv: []string{"python", "-c", str}}
 	e := NewExecer()
+	process, err := e.Exec(cmd)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	// Check for growing memory usage at [.2, .4]s. Then check that the usage is a reasonable minimum value (25MB).
+	prevUsage := 0
+	for i := 0; i < 2; i++ {
+		time.Sleep(200 * time.Millisecond)
+		if newUsage, err := e.memUsage(process.(*osProcess).cmd.Process.Pid); err != nil {
+			t.Fatalf(err.Error())
+		} else if int(newUsage) <= prevUsage {
+			t.Fatalf("Expected growing memory, got: %d -> %d @%dms", prevUsage, newUsage, (i+1)*200)
+		} else {
+			prevUsage = int(newUsage)
+		}
+	}
+	if prevUsage < 25*1024*1024 {
+		t.Fatalf("Expected usage to be at least 25MB, was: %dB", prevUsage)
+	}
+	if prevUsage > 250*1024*1024 {
+		t.Fatalf("Expected usage to be less than 200MB, was: %dB", prevUsage)
+	}
+
+	process.Abort()
+}
+
+func TestMemCap(t *testing.T) {
+	str := `import time; exec("x=[]\nfor i in range(5):\n x.append(' ' * 10*1024*1024)\n time.sleep(.1)")`
+	cmd := execer.Command{Argv: []string{"python", "-c", str}}
+	e := NewBoundedExecer(execer.Memory(50*1024*1024), stats.NilStatsReceiver())
 	process, err := e.Exec(cmd)
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -206,7 +206,7 @@ func (p *osProcess) Abort() (result execer.ProcessStatus) {
 	result.ExitCode = -1
 	result.Error = "Aborted."
 
-	err = p.cmd.Process.Kill()
+	err := p.cmd.Process.Kill()
 	if err != nil {
 		result.Error = "Aborted. Couldn't kill process."
 	}

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -85,6 +85,10 @@ type osProcess struct {
 	mutex  sync.Mutex
 }
 
+// TODO(rcouto): More we can do here to make sure we're
+// cleaning up after ourselves completely / not leaving
+// orphaned processes behind
+//
 // Periodically check to make sure memory constraints are respected,
 // and clean up after ourselves when the process has completed
 func (e *osExecer) monitorMem(p *osProcess) {

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -21,20 +21,19 @@ import (
 )
 
 func NewExecer() *osExecer {
-	return &osExecer{OS: runtime.GOOS}
+	return &osExecer{}
 }
 
 // For now memory can be capped on a per-execer basis rather than a per-command basis.
 // This is ok since we currently (Q1 2017) only support one run at a time in our codebase.
 func NewBoundedExecer(memCap execer.Memory, stat stats.StatsReceiver) *osExecer {
-	return &osExecer{memCap: memCap, stat: stat.Scope("osexecer"), OS: runtime.GOOS}
+	return &osExecer{memCap: memCap, stat: stat.Scope("osexecer")}
 }
 
 type osExecer struct {
 	// Best effort monitoring of command to kill it if resident memory usage exceeds this cap. Ignored if zero.
 	memCap execer.Memory
 	stat   stats.StatsReceiver
-	OS     string
 }
 
 type WriterDelegater interface {
@@ -169,7 +168,7 @@ func (e *osExecer) monitorMem(p *osProcess) {
 // Other architectures are yet to be investigated
 func (e *osExecer) memUsage(pid int) (execer.Memory, error) {
 	var id string
-	switch e.OS {
+	switch runtime.GOOS {
 	case "darwin":
 		id = "pgid"
 	default:

--- a/runner/execer/os/os_execer.go
+++ b/runner/execer/os/os_execer.go
@@ -136,7 +136,7 @@ func (p *osProcess) monitorMem(memCap execer.Memory, stat stats.StatsReceiver) {
 				ps, err := exec.Command("ps", "-u", os.Getenv("USER"), "-opid,sess,ppid,pgid,rss,args").CombinedOutput()
 				log.WithFields(
 					log.Fields{
-						"pid", pid,
+						"pid": pid,
 						"ps":  string(ps),
 						"err": err,
 					}).Infof("ps after increasing mem_cap utilization for pid %d:", pid)
@@ -201,9 +201,7 @@ func (p *osProcess) Abort() (result execer.ProcessStatus) {
 	result.ExitCode = -1
 	result.Error = "Aborted."
 
-	// pid and pgid should be equal (because SysProcAttr{Setgpid: true}).
-	// We want to kill the current process and all processes within
-	// its process group.
+	// pid and pgid should be equal (because SysProcAttr{Setgpid: true})
 	pid := p.cmd.Process.Pid
 	pgid, err := syscall.Getpgid(pid)
 	if err != nil {
@@ -266,9 +264,9 @@ print total
 
 // Kill process along with all child processes, assuming no child processes called setpgid
 func cleanupProcs(pgid int) (err error) {
-	log.Info("Cleaning up process group %d", pgid)
+	log.Info("Cleaning up pgid %d", pgid)
 	if err = syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
-		log.Errorf("Error cleaning up after process group %d: %v", pgid, err)
+		log.Errorf("Error cleaning up after pgid %d: %v", pgid, err)
 	}
 	return err
 }


### PR DESCRIPTION
- Kill lingering processes with same pgid as monitored command on both success and fail

- Monitor mem usage using process group id instead of parent process id. Gives us a more accurate measure of worker memory usage.

- Structured logging to make verbose ps calls easier to parse