### PR TITLE
Jbruno/dx2186 new metrics - worker download/upload

### DIFF
--- a/binaries/daemon/main.go
+++ b/binaries/daemon/main.go
@@ -58,7 +58,7 @@ func main() {
 		log.Fatal("Cannot create OutputCreator: ", err)
 	}
 	filer := snapshots.MakeTempFiler(tempDir)
-	r := runners.NewQueueRunner(ex, filer, nil, outputCreator, tmp, *qLen)
+	r := runners.NewQueueRunner(ex, filer, nil, outputCreator, tmp, *qLen, nil)
 	h := server.NewHandler(r, filer, 50*time.Millisecond)
 	s, err := server.NewServer(h)
 	if err != nil {

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -357,6 +357,17 @@ const (
 	WorkerActiveRunsGauge = "activeRunsGauge"
 
 	/*
+		the number of times the worker downloaded a snapshot from bundlestore
+	*/
+	WorkerDownloads = "workerDownloads"
+
+	/*
+		the amount of time spent downloading snapshots to the worker.  This includes time for
+		successful as well as erroring downloads
+	*/
+	WorkerDownloadLatency_ms = "workerDownloadLatency_ms"
+
+	/*
 		The number of runs in the worker's statusAll() response that are not currently running
 		TODO - this includes runs that are waiting to start - will not be accurate if we go to a
 		worker that can run multiple commands
@@ -406,6 +417,17 @@ const (
 		Time since the most recent run, status, abort, erase request
 	*/
 	WorkerTimeSinceLastContactGauge_ms = "timeSinceLastContactGauge_ms"
+
+	/*
+		the number of times the worker uploaded a snapshot to bundlestore
+	*/
+	WorkerUploads = "workerUploads"
+
+	/*
+		the amount of time spent uploading snapshots to bundlestore.  This includes time for
+		successful as well as erroring uploads
+	*/
+	WorkerUploadLatency_ms = "workerUploadLatency_ms"
 
 	/*
 		Time since the worker started

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -362,6 +362,11 @@ const (
 	WorkerDownloads = "workerDownloads"
 
 	/*
+		the number of times a worker's inti failed.  Should be at most 1 for each worker
+	*/
+	WorkerDownloadInitFailure = "workerDownloadInitFailure"
+
+	/*
 		the amount of time spent downloading snapshots to the worker.  This includes time for
 		successful as well as erroring downloads
 	*/

--- a/common/stats/verify_stats.go
+++ b/common/stats/verify_stats.go
@@ -18,12 +18,24 @@ type RuleChecker struct {
 	checker func(interface{}, interface{}) bool
 }
 
+func nilCheck(a, b interface{}) (nilFound, eqValues bool) {
+	nilFound = false
+	if b == nil && a == nil {
+		nilFound = true
+		eqValues = true
+	} else if b == nil || a == nil {
+		nilFound = true
+		eqValues = false
+	}
+	return
+}
+
 /*
 errors if a is not float64, returns true if a == b
 */
 func floatEqTest(a, b interface{}) bool {
-	if b == nil && a == nil {
-		return true
+	if nilFound, eqValue := nilCheck(a, b); nilFound {
+		return eqValue
 	}
 	aflt := a.(float64)
 	bflt := b.(float64)
@@ -36,8 +48,8 @@ var FloatEqTest = RuleChecker{name: "floatEqTest", checker: floatEqTest}
 errors if a is not float64, returns true if a > b
 */
 func floatGTTest(a, b interface{}) bool {
-	if b == nil && a == nil {
-		return true
+	if nilFound, eqValue := nilCheck(a, b); nilFound {
+		return eqValue
 	}
 	aflt := a.(float64)
 	bflt := b.(float64)
@@ -50,8 +62,8 @@ var FloatGTTest = RuleChecker{name: "floatGTTest", checker: floatGTTest}
 errors if a is not int64, returns true if a == b
 */
 func int64EqTest(a, b interface{}) bool {
-	if b == nil && a == nil {
-		return true
+	if nilFound, eqValue := nilCheck(a, b); nilFound {
+		return eqValue
 	}
 	aint := a.(int64)
 	bint := b.(int)
@@ -113,7 +125,7 @@ func VerifyStats(tag string, statsRegistry StatsRegistry, t *testing.T, contains
 }
 
 func PPrintStats(tag string, statsRegistry StatsRegistry) {
-	fmt.Printf("%s\n", tag)
+	fmt.Printf("%s:  Stats Registry:\n", tag)
 	asFinagleRegistry, _ := statsRegistry.(*finagleStatsRegistry)
 	regBytes, _ := asFinagleRegistry.MarshalJSONPretty()
 	fmt.Printf("%s\n", regBytes)

--- a/daemon/server/handler_test.go
+++ b/daemon/server/handler_test.go
@@ -24,7 +24,8 @@ func TestDaemonExample(t *testing.T) {
 	out, _ := runners.NewHttpOutputCreator(localTmp, "")
 	filer := snapshots.MakeTempFiler(filerTmp)
 	ex := execer.NewExecer()
-	run := runners.NewSingleRunner(ex, filer, nil, out, filerTmp)
+
+	run := runners.NewSingleRunner(ex, filer, nil, out, filerTmp, nil)
 	handler := NewHandler(run, filer, 50*time.Millisecond)
 
 	// Populate the paths we want to ingest.

--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -76,7 +76,6 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	}
 
 	go func() {
-
 		if cmd.SnapshotID == "" {
 			//TODO: we don't want this logic to live here, these decisions should be made at a higher level.
 			if len(cmd.Argv) > 0 && cmd.Argv[0] != execers.UseSimExecerArg {

--- a/runner/runners/polling_test.go
+++ b/runner/runners/polling_test.go
@@ -14,7 +14,7 @@ import (
 func setupPoller() (*execers.SimExecer, *ChaosRunner, runner.Service) {
 	tmp, _ := temp.NewTempDir("", "runner_polling_test")
 	ex := execers.NewSimExecer()
-	single := NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, NewNullOutputCreator(), tmp)
+	single := NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, NewNullOutputCreator(), tmp, nil)
 	chaos := NewChaosRunner(single)
 	var nower runner.StatusQueryNower
 	nower = chaos

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
 	"github.com/scootdev/scoot/runner/execer"
@@ -24,14 +25,18 @@ type cmdAndID struct {
 // NewQueueRunner creates a new Service that uses a Queue
 // The init chan is optional and may be nil if the filer has no initializion step.
 func NewQueueRunner(
-	exec execer.Execer, filer snapshot.Filer, idc snapshot.InitDoneCh, output runner.OutputCreator, tmp *temp.TempDir, capacity int,
-) runner.Service {
+	exec execer.Execer, filer snapshot.Filer, idc snapshot.InitDoneCh, output runner.OutputCreator, tmp *temp.TempDir, capacity int, stat stats.StatsReceiver) runner.Service {
+
+	if stat == nil {
+		stat = stats.NilStatsReceiver()
+	}
+
 	history := 1
 	if capacity > 0 {
 		history = 0 // unlimited if acting as a queue (vs single runner).
 	}
 	statusManager := NewStatusManager(history)
-	inv := NewInvoker(exec, filer, output, tmp)
+	inv := NewInvoker(exec, filer, output, tmp, stat)
 	controller := &QueueController{statusManager: statusManager, inv: inv, capacity: capacity}
 	run := &Service{controller, statusManager, statusManager}
 
@@ -53,8 +58,8 @@ func NewQueueRunner(
 }
 
 func NewSingleRunner(
-	exec execer.Execer, filer snapshot.Filer, idc snapshot.InitDoneCh, output runner.OutputCreator, tmp *temp.TempDir) runner.Service {
-	return NewQueueRunner(exec, filer, idc, output, tmp, 0)
+	exec execer.Execer, filer snapshot.Filer, idc snapshot.InitDoneCh, output runner.OutputCreator, tmp *temp.TempDir, stat stats.StatsReceiver) runner.Service {
+	return NewQueueRunner(exec, filer, idc, output, tmp, 0, stat)
 }
 
 // QueueController maintains a queue of commands to run (up to capacity).

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -45,6 +45,7 @@ func NewQueueRunner(
 		go func() {
 			err := <-idc
 			if err != nil {
+				stat.Counter(stats.WorkerDownloadInitFailure).Inc(1)
 				statusManager.UpdateService(runner.ServiceStatus{Initialized: false, Error: err})
 			} else {
 				statusManager.UpdateService(runner.ServiceStatus{Initialized: true})

--- a/runner/runners/queue_test.go
+++ b/runner/runners/queue_test.go
@@ -160,7 +160,8 @@ func setup(capacity int, t *testing.T) *env {
 	if err != nil {
 		t.Fatalf("Test setup() failed getting output creator:%s", err.Error())
 	}
-	r := NewQueueRunner(sim, snapshots.MakeInvalidFiler(), nil, outputCreator, tmpDir, capacity)
+
+	r := NewQueueRunner(sim, snapshots.MakeInvalidFiler(), nil, outputCreator, tmpDir, capacity, nil)
 
 	return &env{sim: sim, r: r}
 }

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 	log "github.com/Sirupsen/logrus"
 
-
 	"github.com/scootdev/scoot/common/log/hooks"
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/os/temp"

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -1,13 +1,13 @@
 package runners
 
 import (
+	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
-	log "github.com/Sirupsen/logrus"
 
 	"github.com/scootdev/scoot/common/log/hooks"
 	"github.com/scootdev/scoot/common/stats"
@@ -129,12 +129,11 @@ func TestMemCap(t *testing.T) {
 	}
 }
 
-
 func TestDownloadCounter(t *testing.T) {
 	log.AddHook(hooks.NewContextHook())
 
 	statsReg := stats.NewFinagleStatsRegistry()
-	regFn := func() stats.StatsRegistry {return statsReg}
+	regFn := func() stats.StatsRegistry { return statsReg }
 	stat, _ := stats.NewCustomStatsReceiver(regFn, 0)
 	cmd := &runner.Command{Argv: []string{"ls"}, SnapshotID: "dummySnapshotId"}
 	tmp, _ := temp.TempDirDefault()
@@ -150,7 +149,6 @@ func TestDownloadCounter(t *testing.T) {
 	}
 	// wait for the run to finish
 	r.Query(query, runner.Wait{Timeout: 5 * time.Second})
-
 
 	stats.VerifyStats("", statsReg, t,
 		map[string]stats.Rule{

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+	log "github.com/Sirupsen/logrus"
 
+
+	"github.com/scootdev/scoot/common/log/hooks"
 	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/runner"
@@ -109,7 +112,7 @@ func TestMemCap(t *testing.T) {
 	cmd := &runner.Command{Argv: []string{"python", "-c", str}}
 	tmp, _ := temp.TempDirDefault()
 	e := os_execer.NewBoundedExecer(execer.Memory(25*1024*1024), stats.NilStatsReceiver())
-	r := NewSingleRunner(e, snapshots.MakeNoopFiler(tmp.Dir), nil, NewNullOutputCreator(), tmp)
+	r := NewSingleRunner(e, snapshots.MakeNoopFiler(tmp.Dir), nil, NewNullOutputCreator(), tmp, nil)
 	if _, err := r.Run(cmd); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -127,6 +130,38 @@ func TestMemCap(t *testing.T) {
 	}
 }
 
+
+func TestDownloadCounter(t *testing.T) {
+	log.AddHook(hooks.NewContextHook())
+
+	statsReg := stats.NewFinagleStatsRegistry()
+	regFn := func() stats.StatsRegistry {return statsReg}
+	stat, _ := stats.NewCustomStatsReceiver(regFn, 0)
+	cmd := &runner.Command{Argv: []string{"ls"}, SnapshotID: "dummySnapshotId"}
+	tmp, _ := temp.TempDirDefault()
+	e := os_execer.NewExecer()
+	r := NewSingleRunner(e, snapshots.MakeNoopFiler(tmp.Dir), nil, NewNullOutputCreator(), tmp, stat)
+	if _, err := r.Run(cmd); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	query := runner.Query{
+		AllRuns: true,
+		States:  runner.MaskForState(runner.DONE_MASK),
+	}
+	// wait for the run to finish
+	r.Query(query, runner.Wait{Timeout: 5 * time.Second})
+
+
+	stats.VerifyStats("", statsReg, t,
+		map[string]stats.Rule{
+			stats.WorkerUploadLatency_ms + ".avg":   {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.WorkerDownloadLatency_ms + ".avg": {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.WorkerUploads:                     {Checker: stats.Int64EqTest, Value: 1},
+			stats.WorkerDownloads:                   {Checker: stats.Int64EqTest, Value: 1},
+		})
+}
+
 func newRunner() (runner.Service, *execers.SimExecer) {
 	sim := execers.NewSimExecer()
 	tmpDir, err := temp.TempDirDefault()
@@ -138,6 +173,6 @@ func newRunner() (runner.Service, *execers.SimExecer) {
 	if err != nil {
 		panic(err)
 	}
-	r := NewSingleRunner(sim, snapshots.MakeInvalidFiler(), nil, outputCreator, tmpDir)
+	r := NewSingleRunner(sim, snapshots.MakeInvalidFiler(), nil, outputCreator, tmpDir, nil)
 	return r, sim
 }

--- a/sched/scheduler/cluster_state_test.go
+++ b/sched/scheduler/cluster_state_test.go
@@ -165,9 +165,9 @@ func Test_ClusterState_NodeGroups(t *testing.T) {
 
 	stats.VerifyStats("1st stats check:", statsRegistry, t,
 		map[string]stats.Rule{
-			"availableNodes": {Checker: stats.Int64EqTest, Value: 1},
-			"idleNodes":      {Checker: stats.Int64EqTest, Value: 1},
-			"lostNodes":      {Checker: stats.Int64EqTest, Value: 3},
+			stats.ClusterAvailableNodes: {Checker: stats.Int64EqTest, Value: 1},
+			stats.ClusterIdleNodes:      {Checker: stats.Int64EqTest, Value: 1},
+			stats.ClusterLostNodes:      {Checker: stats.Int64EqTest, Value: 3},
 		})
 
 	// Remove node2 and make sure its state is set correctly.
@@ -190,9 +190,9 @@ func Test_ClusterState_NodeGroups(t *testing.T) {
 
 	stats.VerifyStats("2nd stats check:", statsRegistry, t,
 		map[string]stats.Rule{
-			"availableNodes": {Checker: stats.Int64EqTest, Value: 1},
-			"idleNodes":      {Checker: stats.Int64EqTest, Value: 1},
-			"lostNodes":      {Checker: stats.Int64EqTest, Value: 3},
+			stats.ClusterAvailableNodes: {Checker: stats.Int64EqTest, Value: 1},
+			stats.ClusterIdleNodes:      {Checker: stats.Int64EqTest, Value: 1},
+			stats.ClusterLostNodes:      {Checker: stats.Int64EqTest, Value: 3},
 		})
 
 	// Re-add node2 and set the rest as init'd, then check nodes/suspendedNodes.
@@ -213,9 +213,9 @@ func Test_ClusterState_NodeGroups(t *testing.T) {
 
 	stats.VerifyStats("3rd stats check:", statsRegistry, t,
 		map[string]stats.Rule{
-			"availableNodes": {Checker: stats.Int64EqTest, Value: 4},
-			"idleNodes":      {Checker: stats.Int64EqTest, Value: 3},
-			"lostNodes":      {Checker: stats.Int64EqTest, Value: 0},
+			stats.ClusterAvailableNodes: {Checker: stats.Int64EqTest, Value: 4},
+			stats.ClusterIdleNodes:      {Checker: stats.Int64EqTest, Value: 3},
+			stats.ClusterLostNodes:      {Checker: stats.Int64EqTest, Value: 0},
 		})
 	// Test the the right idle/busy maps are filled out for each snapshotId.
 	cs.taskScheduled("node1", "job1", "task1", "snapA")

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -112,9 +112,9 @@ func Test_StatefulScheduler_ScheduleJobSuccess(t *testing.T) {
 
 	stats.VerifyStats("", statsRegistry, t,
 		map[string]stats.Rule{
-			"schedJobsCounter":        {Checker: stats.Int64EqTest, Value: 1},
-			"schedJobLatency_ms.avg":  {Checker: stats.FloatGTTest, Value: 0.0},
-			"schedJobRequestsCounter": {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedJobsCounter:            {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedJobLatency_ms + ".avg": {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedJobRequestsCounter:     {Checker: stats.Int64EqTest, Value: 1},
 		})
 }
 
@@ -145,9 +145,9 @@ func Test_StatefulScheduler_ScheduleJobFailure(t *testing.T) {
 
 	stats.VerifyStats("", statsRegistry, t,
 		map[string]stats.Rule{
-			"schedJobsCounter":        {Checker: stats.DoesNotExistTest, Value: nil},
-			"schedJobLatency_ms.avg":  {Checker: stats.FloatGTTest, Value: 0.0},
-			"schedJobRequestsCounter": {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedJobsCounter:            {Checker: stats.DoesNotExistTest, Value: nil},
+			stats.SchedJobLatency_ms + ".avg": {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedJobRequestsCounter:     {Checker: stats.Int64EqTest, Value: 1},
 		})
 }
 
@@ -173,9 +173,9 @@ func Test_StatefulScheduler_AddJob(t *testing.T) {
 
 	stats.VerifyStats("", statsRegistry, t,
 		map[string]stats.Rule{
-			"schedAcceptedJobsGauge":    {Checker: stats.Int64EqTest, Value: 1},
-			"schedInProgressTasksGauge": {Checker: stats.Int64EqTest, Value: 2},
-			"schedNumRunningTasksGauge": {Checker: stats.Int64EqTest, Value: 2},
+			stats.SchedAcceptedJobsGauge:    {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedInProgressTasksGauge: {Checker: stats.Int64EqTest, Value: 2},
+			stats.SchedNumRunningTasksGauge: {Checker: stats.Int64EqTest, Value: 2},
 		})
 }
 
@@ -250,7 +250,7 @@ func Test_StatefulScheduler_TaskGetsMarkedCompletedAfterMaxRetriesFailedRuns(t *
 	deps.rf = func(cluster.Node) runner.Service {
 		ex := execers.NewDoneExecer()
 		ex.ExecError = errors.New("Test - failed to exec")
-		return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
+		return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp, nil)
 	}
 
 	s := makeStatefulSchedulerDeps(deps)
@@ -449,8 +449,8 @@ func Test_StatefulScheduler_KillNotStartedJob(t *testing.T) {
 
 	stats.VerifyStats("first stage", statsRegistry, t,
 		map[string]stats.Rule{
-			"schedAcceptedJobsGauge": {Checker: stats.Int64EqTest, Value: 1},
-			"schedWaitingJobsGauge":  {Checker: stats.Int64EqTest, Value: 0},
+			stats.SchedAcceptedJobsGauge: {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedWaitingJobsGauge:  {Checker: stats.Int64EqTest, Value: 0},
 		})
 
 	// put a job with 3 tasks in the queue - all tasks should be in NotStarted state
@@ -461,8 +461,8 @@ func Test_StatefulScheduler_KillNotStartedJob(t *testing.T) {
 
 	stats.VerifyStats("second stage", statsRegistry, t,
 		map[string]stats.Rule{
-			"schedAcceptedJobsGauge": {Checker: stats.Int64EqTest, Value: 2},
-			"schedWaitingJobsGauge":  {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedAcceptedJobsGauge: {Checker: stats.Int64EqTest, Value: 2},
+			stats.SchedWaitingJobsGauge:  {Checker: stats.Int64EqTest, Value: 1},
 		})
 
 	// kill the second job
@@ -612,7 +612,7 @@ func getDepsWithPausingWorker() (*schedulerDeps, []*execers.SimExecer) {
 		sc:        sagalogs.MakeInMemorySagaCoordinator(),
 		rf: func(n cluster.Node) runner.Service {
 			ex := execers.NewSimExecer()
-			runner := runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
+			runner := runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp, nil)
 			return runner
 		},
 		config: SchedulerConfig{

--- a/sched/scheduler/task_runner_test.go
+++ b/sched/scheduler/task_runner_test.go
@@ -250,7 +250,7 @@ func Test_runTaskWithRunRetry(t *testing.T) {
 
 	stats.VerifyStats("", statsRegistry, t,
 		map[string]stats.Rule{
-			"taskStartRetries": {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedTaskStartRetries: {Checker: stats.Int64EqTest, Value: 1},
 		})
 }
 

--- a/sched/worker/workers/makers.go
+++ b/sched/worker/workers/makers.go
@@ -19,7 +19,7 @@ func MakeInmemoryWorker(node cluster.Node, tmp *temp.TempDir) runner.Service {
 // Makes a worker suitable for using as an in-memory worker.
 func MakeDoneWorker(tmp *temp.TempDir) runner.Service {
 	ex := execers.NewDoneExecer()
-	r := runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
+	r := runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp, nil)
 	chaos := runners.NewChaosRunner(r)
 	chaos.SetDelay(time.Duration(50) * time.Millisecond)
 	return chaos
@@ -28,5 +28,5 @@ func MakeDoneWorker(tmp *temp.TempDir) runner.Service {
 // Makes a worker that uses a SimExecer. This is suitable for testing.
 func MakeSimWorker(tmp *temp.TempDir) runner.Service {
 	ex := execers.NewSimExecer()
-	return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp)
+	return runners.NewSingleRunner(ex, snapshots.MakeInvalidFiler(), nil, runners.NewNullOutputCreator(), tmp, nil)
 }

--- a/scootapi/server/server_test.go
+++ b/scootapi/server/server_test.go
@@ -52,12 +52,12 @@ func Test_RequestCounters(t *testing.T) {
 
 	stats.VerifyStats("", statsRegistry, t,
 		map[string]stats.Rule{
-			"runJobRpmCounter":        {Checker: stats.Int64EqTest, Value: 1},
-			"runJobLatency_ms.avg":    {Checker: stats.FloatGTTest, Value: 0.0},
-			"jobStatusRpmCounter":     {Checker: stats.Int64EqTest, Value: 1},
-			"jobStatusLatency_ms.avg": {Checker: stats.FloatGTTest, Value: 0.0},
-			"jobKillRpmCounter":       {Checker: stats.Int64EqTest, Value: 1},
-			"jobKillLatency_ms.avg":   {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedServerRunJobCounter:        {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedServerRunJobLatency_ms+".avg":    {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedServerJobStatusCounter:     {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedServerJobStatusLatency_ms+".avg": {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedServerJobKillCounter:       {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedServerJobKillLatency_ms+".avg":   {Checker: stats.FloatGTTest, Value: 0.0},
 		})
 }
 

--- a/scootapi/server/server_test.go
+++ b/scootapi/server/server_test.go
@@ -52,12 +52,12 @@ func Test_RequestCounters(t *testing.T) {
 
 	stats.VerifyStats("", statsRegistry, t,
 		map[string]stats.Rule{
-			stats.SchedServerRunJobCounter:        {Checker: stats.Int64EqTest, Value: 1},
-			stats.SchedServerRunJobLatency_ms+".avg":    {Checker: stats.FloatGTTest, Value: 0.0},
-			stats.SchedServerJobStatusCounter:     {Checker: stats.Int64EqTest, Value: 1},
-			stats.SchedServerJobStatusLatency_ms+".avg": {Checker: stats.FloatGTTest, Value: 0.0},
-			stats.SchedServerJobKillCounter:       {Checker: stats.Int64EqTest, Value: 1},
-			stats.SchedServerJobKillLatency_ms+".avg":   {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedServerRunJobCounter:                {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedServerRunJobLatency_ms + ".avg":    {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedServerJobStatusCounter:             {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedServerJobStatusLatency_ms + ".avg": {Checker: stats.FloatGTTest, Value: 0.0},
+			stats.SchedServerJobKillCounter:               {Checker: stats.Int64EqTest, Value: 1},
+			stats.SchedServerJobKillLatency_ms + ".avg":   {Checker: stats.FloatGTTest, Value: 0.0},
 		})
 }
 


### PR DESCRIPTION
added metrics to track download/upload latency and counts from the worker - updated worker creation functions to allow passing in the stats collector.

updated the tests to use the constants instead of hard-coded names (forgot to make these changes in the last PR)
