### PR TITLE
Add support for periodic repo updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,13 @@ _testmain.go
 .DS_Store
 coverage.txt
 *~
+
+# Vim (superior to emacs)
+*.swp
+
 # Emacs save files have literal pound signs/octothorpes/hashtags in them
 # So the \# escapes # as comment syntax
 \#*#
 .\#*
+
 .scootdata/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: go
 
 go:
-  - 1.7.x
+  - 1.7
 
 git:
     submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: go
 
 go:
-  - 1.7
+  - 1.7.x
 
 git:
     submodules: false

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,12 @@ format:
 vet:
 	go vet $$(go list ./... | grep -v /vendor/)
 
-test:
+coverage:
+	sh testCoverage.sh
+
+test-unit-property:
 	# Runs only unit tests and property tests
 	go test -race -tags=property_test $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
-	sh testCoverage.sh
 
 test-unit:
 	# Runs only unit tests
@@ -58,6 +60,10 @@ test-integration:
 	go test -race -tags="integration property_test" $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 
 testlocal: generate test
+
+testonly: test-unit-property
+
+test: test-unit-property coverage
 
 swarmtest:
 	# Setup a local schedule against local workers (--strategy local.local)

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ BUILDTIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILDDATE := $(shell date -u +"%B %d, %Y")
 PROJECT_URL := "https://github.com/scootdev/scoot"
 
-GO15VENDOREXPERIMENT := 1
-export GO15VENDOREXPERIMENT
-
 default:
 	go build $$(go list ./... | grep -v /vendor/)
 

--- a/binaries/scoot-snapshot-db/main.go
+++ b/binaries/scoot-snapshot-db/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/scootdev/scoot/common/dialer"
 	"github.com/scootdev/scoot/common/log/hooks"
+	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/os/temp"
 	"github.com/scootdev/scoot/scootapi"
 	"github.com/scootdev/scoot/snapshot"
@@ -86,8 +87,12 @@ func (i *injector) Inject() (snapshot.DB, error) {
 	}
 
 	store := bundlestore.MakeHTTPStore(url)
-	return gitdb.MakeDBFromRepo(dataRepo, nil, tempDir, nil, nil, &gitdb.BundlestoreConfig{Store: store},
-		gitdb.AutoUploadBundlestore), nil
+	return gitdb.MakeDBFromRepo(
+			dataRepo, nil, tempDir, nil, nil,
+			&gitdb.BundlestoreConfig{Store: store},
+			gitdb.AutoUploadBundlestore,
+			stats.NilStatsReceiver()),
+		nil
 }
 
 func removeTemp() {

--- a/binaries/scoot-snapshot-db/main.go
+++ b/binaries/scoot-snapshot-db/main.go
@@ -86,7 +86,7 @@ func (i *injector) Inject() (snapshot.DB, error) {
 	}
 
 	store := bundlestore.MakeHTTPStore(url)
-	return gitdb.MakeDBFromRepo(dataRepo, tempDir, nil, nil, &gitdb.BundlestoreConfig{Store: store},
+	return gitdb.MakeDBFromRepo(dataRepo, nil, tempDir, nil, nil, &gitdb.BundlestoreConfig{Store: store},
 		gitdb.AutoUploadBundlestore), nil
 }
 

--- a/common/stats/stats_names.go
+++ b/common/stats/stats_names.go
@@ -83,17 +83,6 @@ const (
 	*/
 	ClusterLostNodes = "lostNodes"
 
-	/************************** Git Cloner ***************************/
-	/*
-		the number of failures trying to clone
-	*/
-	GitClonerInitFailures = "clonerInitFailures"
-
-	/*
-		the amount of time it took to clone
-	*/
-	GitClonerInitLatency_ms = "clonerInitLatency_ms"
-
 	/************************* Groupcache Metrics ***************************/ // TODO verify/update all groupcache descriptions
 	/*
 		the number of time groupcache tried to determine if a bundle existed
@@ -411,4 +400,25 @@ const (
 		Time since the worker started
 	*/
 	WorkerUptimeGauge_ms = "uptimeGauge_ms"
+
+	/****************************** Git Metrics **********************************************/
+	/*
+		The number of failures trying to init a ref clone
+	*/
+	GitClonerInitFailures = "clonerInitFailures"
+
+	/*
+		The amount of time it took to init a ref clone
+	*/
+	GitClonerInitLatency_ms = "clonerInitLatency_ms"
+
+	/*
+		The number of times a gitfiler.Checkouter Checkout had to resort to a git fetch
+	*/
+	GitFilerCheckoutFetches = "gitfilerCheckoutFetches"
+
+	/*
+		The number of times a gitdb stream backend had to resort to a git fetch
+	*/
+	GitStreamUpdateFetches = "gitStreamUpdateFetches"
 )

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -161,7 +161,9 @@ func (c *QueueController) loop() {
 		// Prefer to run an update first if we have one scheduled
 		select {
 		case <-c.updateCh:
-			c.filer.Update()
+			if err := c.filer.Update(); err != nil {
+				log.Errorf("Error running Filer Update: %v\n", err)
+			}
 			justUpdated = true
 		default:
 		}
@@ -174,7 +176,9 @@ func (c *QueueController) loop() {
 			if justUpdated {
 				justUpdated = false
 			} else {
-				c.filer.Update()
+				if err := c.filer.Update(); err != nil {
+					log.Errorf("Error running Filer Update: %v\n", err)
+				}
 			}
 
 		case cmdID, ok := <-c.startCh:

--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -14,10 +14,11 @@ Key objects (not exhaustive, see code or godoc for more):
   * _FileCursor_ - interface for reading specific segments of files
 * __Higher-level abstractions for filesystem data__ - implementations in snapshot/snaphots/
   * _DB_ - interface to deal with Snapshots. Should replace the types below.
-  * _Filer_ - interface for treating snapshots as files, includes Checkouter and Ingester
+  * _Filer_ - interface for treating snapshots as files, includes Checkouter, Ingester and Updater
   * _Checkout_ - Specific instance or "checkout" of a snapshot
   * _Checkouter_ - Wrapping interface for managing snapshots on the local filesystem
   * _Ingester_ - interface for creating snapshots from the local filesystem
+  * _Updater_ - interface for updating underlying resource a Filer is utilizing
 * __git specific objects__
   * _package gitfiler_ - for checking out and handling snapshots from Git
     * _RepoPool_ - for handling concurrent access to Git repos

--- a/snapshot/db.go
+++ b/snapshot/db.go
@@ -1,8 +1,6 @@
 package snapshot
 
 import (
-	"time"
-
 	"github.com/scootdev/scoot/snapshot/git/repo"
 )
 
@@ -54,19 +52,10 @@ type Reader interface {
 	ExportGitCommit(id ID, exportRepo *repo.Repository) (commit string, err error)
 }
 
-// Updater allows updating the underlying DB resource
-type ResourceUpdater interface {
-	// Update triggers an update of the underlying resource
-	Update() error
-
-	// UpdateInterval retrieves the specified interval for updating the underlying resource
-	UpdateInterval() time.Duration
-}
-
 // DB is the full read-write Snapshot Database, allowing creation and reading of Snapshots,
 // and updating of the underlying DB resource.
 type DB interface {
 	Creator
 	Reader
-	ResourceUpdater
+	Updater
 }

--- a/snapshot/db.go
+++ b/snapshot/db.go
@@ -1,6 +1,8 @@
 package snapshot
 
 import (
+	"time"
+
 	"github.com/scootdev/scoot/snapshot/git/repo"
 )
 
@@ -48,8 +50,19 @@ type Reader interface {
 	ExportGitCommit(id ID, exportRepo *repo.Repository) (commit string, err error)
 }
 
-// DB is the full read-write Snapshot Database, allowing creation and reading of Snapshots.
+// Updater allows updating the underlying DB resource
+type ResourceUpdater interface {
+	// Update triggers an update of the underlying resource
+	Update() error
+
+	// UpdateInterval retrieves the specified interval for updating the underlying resource
+	UpdateInterval() time.Duration
+}
+
+// DB is the full read-write Snapshot Database, allowing creation and reading of Snapshots,
+// and updating of the underlying DB resource.
 type DB interface {
 	Creator
 	Reader
+	ResourceUpdater
 }

--- a/snapshot/filer.go
+++ b/snapshot/filer.go
@@ -50,7 +50,7 @@ type Ingester interface {
 	IngestMap(srcToDest map[string]string) (id string, err error)
 }
 
-const NoDuration time.Duration = time.Duration(0) * time.Second
+const NoDuration time.Duration = time.Duration(0)
 
 // Updater allows Filers to have a means to manage updates on the underlying resources
 type Updater interface {

--- a/snapshot/git/gitdb/db.go
+++ b/snapshot/git/gitdb/db.go
@@ -87,7 +87,7 @@ type RepoIniter interface {
 // Interface for defining update behavior for an underlying repo.Repository.
 // Provides an update mechanism and an interval definition
 type RepoUpdater interface {
-	Update() error
+	Update(r *repo.Repository) error
 	UpdateInterval() time.Duration
 }
 
@@ -147,7 +147,7 @@ func (db *DB) updateRepo() error {
 	if db.updater == nil {
 		return nil
 	}
-	return db.updater.Update()
+	return db.updater.Update(db.dataRepo)
 }
 
 // Returns RepoUpdater's interval if an updater exists, or a zero duration

--- a/snapshot/git/gitdb/db_test.go
+++ b/snapshot/git/gitdb/db_test.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/scootdev/scoot/common/stats"
 	"github.com/scootdev/scoot/os/temp"
 	snap "github.com/scootdev/scoot/snapshot"
 	"github.com/scootdev/scoot/snapshot/bundlestore"
@@ -216,7 +217,8 @@ func TestInitUpdate(t *testing.T) {
 		RefSpec: "refs/remotes/ro/master",
 	}
 
-	db := MakeDBNewRepo(&bundleIniter{mirror, ro}, &pullUpdater{rw.Dir()}, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
+	db := MakeDBNewRepo(&bundleIniter{mirror, ro}, &pullUpdater{rw.Dir()},
+		fixture.tmp, streamCfg, nil, nil, AutoUploadNone, stats.NilStatsReceiver())
 	defer db.Close()
 
 	firstID := db.IDForStreamCommitSHA("sro", firstCommitID)
@@ -256,7 +258,8 @@ func TestInitFails(t *testing.T) {
 		RefSpec: "refs/remotes/ro/master",
 	}
 
-	db := MakeDBNewRepo(&bundleIniter{"/dev/null", fixture.upstream}, nil, fixture.tmp, streamCfg, nil, nil, AutoUploadNone)
+	db := MakeDBNewRepo(&bundleIniter{"/dev/null", fixture.upstream}, nil,
+		fixture.tmp, streamCfg, nil, nil, AutoUploadNone, stats.NilStatsReceiver())
 	defer db.Close()
 
 	ingestDir, err := fixture.tmp.TempDir("ingest_dir")
@@ -374,7 +377,8 @@ func TestBundlestore(t *testing.T) {
 		Store: store,
 	}
 
-	authorDB := MakeDBFromRepo(authorDataRepo, nil, fixture.tmp, streamCfg, nil, bundleCfg, AutoUploadBundlestore)
+	authorDB := MakeDBFromRepo(authorDataRepo, nil, fixture.tmp,
+		streamCfg, nil, bundleCfg, AutoUploadBundlestore, stats.NilStatsReceiver())
 
 	consumerDataRepo, err := createRepo(fixture.tmp, "consumer-data-repo")
 	if err != nil {
@@ -386,7 +390,8 @@ func TestBundlestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	consumerDB := MakeDBFromRepo(consumerDataRepo, nil, fixture.tmp, streamCfg, nil, bundleCfg, AutoUploadBundlestore)
+	consumerDB := MakeDBFromRepo(consumerDataRepo, nil, fixture.tmp,
+		streamCfg, nil, bundleCfg, AutoUploadBundlestore, stats.NilStatsReceiver())
 
 	upstreamMaster, err := fixture.upstream.RunSha("rev-parse", "master")
 	if err != nil {
@@ -600,7 +605,7 @@ func setup() (f *dbFixture, err error) {
 		Prefix: "scoot_reserved",
 	}
 
-	simpleDB := MakeDBFromRepo(dataRepo, nil, tmp, streamCfg, tagsCfg, nil, AutoUploadNone)
+	simpleDB := MakeDBFromRepo(dataRepo, nil, tmp, streamCfg, tagsCfg, nil, AutoUploadNone, stats.NilStatsReceiver())
 
 	authorDataRepo, err := createRepo(tmp, "author-data-repo")
 	if err != nil {
@@ -619,7 +624,7 @@ func setup() (f *dbFixture, err error) {
 		return nil, err
 	}
 
-	authorDB := MakeDBFromRepo(authorDataRepo, nil, tmp, streamCfg, tagsCfg, nil, AutoUploadTags)
+	authorDB := MakeDBFromRepo(authorDataRepo, nil, tmp, streamCfg, tagsCfg, nil, AutoUploadTags, stats.NilStatsReceiver())
 
 	consumerDataRepo, err := createRepo(tmp, "consumer-data-repo")
 	if err != nil {
@@ -634,7 +639,7 @@ func setup() (f *dbFixture, err error) {
 		return nil, err
 	}
 
-	consumerDB := MakeDBFromRepo(consumerDataRepo, nil, tmp, streamCfg, tagsCfg, nil, AutoUploadNone)
+	consumerDB := MakeDBFromRepo(consumerDataRepo, nil, tmp, streamCfg, tagsCfg, nil, AutoUploadNone, stats.NilStatsReceiver())
 
 	return &dbFixture{
 		tmp:        tmp,

--- a/snapshot/git/gitdb/setup.go
+++ b/snapshot/git/gitdb/setup.go
@@ -21,10 +21,10 @@ func Module() ice.Module {
 func (m module) Install(b *ice.MagicBag) {
 	b.PutMany(
 		func(tmp *temp.TempDir) RepoIniter {
-			return &NewRepoIniter{tmp: tmp}
+			return &TmpRepoIniter{tmp: tmp}
 		},
 		func() RepoUpdater {
-			return &NewRepoUpdater{}
+			return &NoopRepoUpdater{}
 		},
 		func(store bundlestore.Store) *BundlestoreConfig {
 			return &BundlestoreConfig{Store: store}
@@ -48,13 +48,15 @@ func (m module) Install(b *ice.MagicBag) {
 	)
 }
 
-// NewRepoIniter creates a new Repo in a temp dir
-type NewRepoIniter struct {
+// Noop/Tmp/Default implementations of gitdb RepoIniter/RepoUpdater interfaces
+
+// TmpRepoIniter creates a new Repo in a temp dir
+type TmpRepoIniter struct {
 	tmp *temp.TempDir
 }
 
 // Init creates a new temp dir and a repo in it
-func (i *NewRepoIniter) Init() (*repo.Repository, error) {
+func (i *TmpRepoIniter) Init() (*repo.Repository, error) {
 	repoTmp, err := i.tmp.TempDir("gitdb-repo-")
 	if err != nil {
 		return nil, err
@@ -63,9 +65,8 @@ func (i *NewRepoIniter) Init() (*repo.Repository, error) {
 	return repo.InitRepo(repoTmp.Dir)
 }
 
-// Noop Repo Updater
-type NewRepoUpdater struct{}
+type NoopRepoUpdater struct{}
 
-func (u *NewRepoUpdater) Update(*repo.Repository) error { return nil }
+func (u *NoopRepoUpdater) Update(*repo.Repository) error { return nil }
 
-func (u *NewRepoUpdater) UpdateInterval() time.Duration { return snap.NoDuration }
+func (u *NoopRepoUpdater) UpdateInterval() time.Duration { return snap.NoDuration }

--- a/snapshot/git/gitdb/setup.go
+++ b/snapshot/git/gitdb/setup.go
@@ -1,6 +1,8 @@
 package gitdb
 
 import (
+	"time"
+
 	"github.com/scootdev/scoot/ice"
 	"github.com/scootdev/scoot/os/temp"
 	snap "github.com/scootdev/scoot/snapshot"
@@ -20,6 +22,9 @@ func (m module) Install(b *ice.MagicBag) {
 	b.PutMany(
 		func(tmp *temp.TempDir) RepoIniter {
 			return &NewRepoIniter{tmp: tmp}
+		},
+		func() RepoUpdater {
+			return &NewRepoUpdater{}
 		},
 		func(store bundlestore.Store) *BundlestoreConfig {
 			return &BundlestoreConfig{Store: store}
@@ -57,3 +62,10 @@ func (i *NewRepoIniter) Init() (*repo.Repository, error) {
 
 	return repo.InitRepo(repoTmp.Dir)
 }
+
+// Noop Repo Updater
+type NewRepoUpdater struct{}
+
+func (u *NewRepoUpdater) Update(*repo.Repository) error { return nil }
+
+func (u *NewRepoUpdater) UpdateInterval() time.Duration { return snap.NoDuration }

--- a/snapshot/git/gitdb/stream.go
+++ b/snapshot/git/gitdb/stream.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/scootdev/scoot/common/stats"
 	snap "github.com/scootdev/scoot/snapshot"
 )
 
@@ -29,7 +30,8 @@ const streamIDText = "stream"
 const streamIDFmt = "%s-%s-%s-%s"
 
 type streamBackend struct {
-	cfg *StreamConfig
+	cfg  *StreamConfig
+	stat stats.StatsReceiver
 }
 
 func (b *streamBackend) parseID(id snap.ID, kind snapshotKind, extraParts []string) (*streamSnapshot, error) {
@@ -88,7 +90,8 @@ func (b *streamBackend) updateStream(name string, db *DB) error {
 		return fmt.Errorf("cannot update stream %s: does not match stream %s", name, db.stream.cfg.Name)
 	}
 
-	// TODO(dbentley): keep stats about fetching (when we do it, last time we did it, etc.)
+	b.stat.Counter(stats.GitStreamUpdateFetches).Inc(1)
+
 	_, err := db.dataRepo.Run("fetch", b.cfg.Remote)
 	return err
 }

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -3,6 +3,7 @@ package gitfiler
 import (
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/scootdev/scoot/snapshot"
 	"github.com/scootdev/scoot/snapshot/git/repo"
@@ -82,9 +83,11 @@ func (c *Checkouter) CheckoutAt(id string, dir string) (co snapshot.Checkout, er
 	return &UnmanagedCheckout{id: id, dir: dir}, nil
 }
 
-// Implement noop ingest so this Checkouter can be passed around as a Filer.
+// Implement noop ingest/update so this Checkouter can be passed around as a Filer.
 func (c *Checkouter) Ingest(string) (string, error)               { return "", nil }
 func (c *Checkouter) IngestMap(map[string]string) (string, error) { return "", nil }
+func (c *Checkouter) Update() error                               { return nil }
+func (c *Checkouter) UpdateInterval() time.Duration               { return snapshot.NoDuration }
 func (c *Checkouter) AsFiler() snapshot.Filer                     { return c }
 
 // Checkout holds one repo that is checked out to a specific ID

--- a/snapshot/git/gitfiler/checkouter.go
+++ b/snapshot/git/gitfiler/checkouter.go
@@ -15,6 +15,7 @@ func NewCheckouter(repos *RepoPool, stat stats.StatsReceiver) *Checkouter {
 }
 
 // Checkouter checks out by checking out in a repo from pool
+// snapshot.Filer implementation
 type Checkouter struct {
 	repos *RepoPool
 	stat  stats.StatsReceiver

--- a/snapshot/git/gitfiler/cloner.go
+++ b/snapshot/git/gitfiler/cloner.go
@@ -15,7 +15,7 @@ import (
 // hardlink. This means the clone is much faster and also takes very little extra hard disk space.
 // Cf. https://git-scm.com/docs/git-clone
 
-// RepoIniter implementation
+// PooledRepoIniter implementation
 // cloner clones a repo using --reference based on a reference repo
 type refCloner struct {
 	refPool   *RepoPool

--- a/snapshot/git/gitfiler/doc.go
+++ b/snapshot/git/gitfiler/doc.go
@@ -1,7 +1,7 @@
 // Package gitfiler offers Scoot Snapshot Filer operations access to git.
 // It does this with a few related by separate structures:
 //
-// RepoIniter is an interface to initialize a Repository.
+// PooledRepoIniter is an interface to initialize a Repository.
 //
 // refCloner gets new repos by running git clone --reference against a reference repo
 //

--- a/snapshot/git/gitfiler/pool.go
+++ b/snapshot/git/gitfiler/pool.go
@@ -12,7 +12,7 @@ type repoAndError struct {
 }
 
 // NewRepoPool creates a new RepoPool populated with existing repos and a initer that can get new ones
-func NewRepoPool(initer RepoIniter,
+func NewRepoPool(initer PooledRepoIniter,
 	stat stats.StatsReceiver,
 	repos []*repo.Repository,
 	doneCh <-chan struct{},
@@ -38,12 +38,12 @@ func NewRepoPool(initer RepoIniter,
 }
 
 // RepoPool lets clients Get a Repository for an operation, and then Release it when done
-// RepoPool can create a new Repository by using a supplied RepoIniter.
+// RepoPool can create a new Repository by using a supplied PooledRepoIniter.
 // New repos can be added by the client by Release'ing a new Repository
 // Cf. sync's Pool
 // Supports maximum pool capacity - 0 is unlimited
 type RepoPool struct {
-	initer RepoIniter
+	initer PooledRepoIniter
 	stat   stats.StatsReceiver
 
 	releaseCh chan repoAndError

--- a/snapshot/git/gitfiler/setup.go
+++ b/snapshot/git/gitfiler/setup.go
@@ -11,14 +11,15 @@ import (
 
 // Utilities for creating Checkouters.
 
-// RepoIniter is an interface for initializing repositories
-type RepoIniter interface {
+// PooledRepoIniter is an interface for initializing repositories
+// Not widely used, renamed from RepoIniter for separation from gitdb.RepoIniter
+type PooledRepoIniter interface {
 	// Init initializes the Repository to use as a reference repository
 	// Takes a StatsReceiver to support instrumenting repo initialization
 	Init(stat stats.StatsReceiver) (*repo.Repository, error)
 }
 
-// RepoIniter implementation
+// PooledRepoIniter implementation
 type ConstantIniter struct {
 	Repo *repo.Repository
 }
@@ -28,7 +29,7 @@ func (g *ConstantIniter) Init(stat stats.StatsReceiver) (*repo.Repository, error
 }
 
 // Util for creating a Pool that will only have a single repo
-func NewSingleRepoPool(repoIniter RepoIniter,
+func NewSingleRepoPool(repoIniter PooledRepoIniter,
 	stat stats.StatsReceiver,
 	doneCh <-chan struct{}) *RepoPool {
 	singlePool := NewRepoPool(repoIniter, stat, []*repo.Repository{}, doneCh, 1)
@@ -36,7 +37,7 @@ func NewSingleRepoPool(repoIniter RepoIniter,
 }
 
 // A Checkouter that checks out from a single repo populated by a NewSingleRepoPool)
-func NewSingleRepoCheckouter(repoIniter RepoIniter,
+func NewSingleRepoCheckouter(repoIniter PooledRepoIniter,
 	stat stats.StatsReceiver,
 	doneCh <-chan struct{}) *Checkouter {
 	pool := NewSingleRepoPool(repoIniter, stat, doneCh)
@@ -44,7 +45,7 @@ func NewSingleRepoCheckouter(repoIniter RepoIniter,
 }
 
 // A Checkouter that creates a new repo with git clone --reference for each checkout
-func NewRefRepoCloningCheckouter(refRepoIniter RepoIniter,
+func NewRefRepoCloningCheckouter(refRepoIniter PooledRepoIniter,
 	stat stats.StatsReceiver,
 	clonesDir *temp.TempDir,
 	doneCh <-chan struct{},

--- a/snapshot/git/gitfiler/setup.go
+++ b/snapshot/git/gitfiler/setup.go
@@ -41,7 +41,7 @@ func NewSingleRepoCheckouter(repoIniter PooledRepoIniter,
 	stat stats.StatsReceiver,
 	doneCh <-chan struct{}) *Checkouter {
 	pool := NewSingleRepoPool(repoIniter, stat, doneCh)
-	return NewCheckouter(pool)
+	return NewCheckouter(pool, stat)
 }
 
 // A Checkouter that creates a new repo with git clone --reference for each checkout
@@ -64,5 +64,5 @@ func NewRefRepoCloningCheckouter(refRepoIniter PooledRepoIniter,
 	}
 
 	pool := NewRepoPool(cloner, stat, clones, doneCh, maxClones)
-	return NewCheckouter(pool)
+	return NewCheckouter(pool, stat)
 }

--- a/snapshot/snapshots/fake_filer.go
+++ b/snapshot/snapshots/fake_filer.go
@@ -21,6 +21,11 @@ func MakeNoopFiler(path string) snapshot.Filer {
 	return MakeFilerFacade(MakeNoopCheckouter(path), MakeNoopIngester(), MakeNoopUpdater())
 }
 
+// Make invalid filer with an updater
+func MakeInvalidFilerUpdater(updater snapshot.Updater) snapshot.Filer {
+	return MakeFilerFacade(MakeInvalidCheckouter(), MakeNoopIngester(), updater)
+}
+
 // FilerFacade creates a Filer from a Checkouter and Ingester
 type FilerFacade struct {
 	snapshot.Checkouter

--- a/snapshot/snapshots/fake_updater.go
+++ b/snapshot/snapshots/fake_updater.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
+
 	"github.com/scootdev/scoot/snapshot"
 )
 
@@ -41,6 +43,7 @@ func (c *CountingUpdater) Update() error {
 		c.wg.Wait()
 	}
 
+	log.Infof("CountingUpdater - Update and increment var %v (current: %d)\n", c.pointer, *c.pointer)
 	*c.pointer += 1
 
 	if c.pause {

--- a/snapshot/snapshots/fake_updater.go
+++ b/snapshot/snapshots/fake_updater.go
@@ -1,0 +1,70 @@
+package snapshots
+
+import (
+	"sync"
+	"time"
+
+	"github.com/scootdev/scoot/snapshot"
+)
+
+// Implements snapshots.Updater
+// Simple updater that supports incrementing an external counter that
+// can be used to verify whether an Update() has run.
+// Supports "pause" to allow race-free control of execution
+// When used with "pause", to step:
+//  1. WaitForUpdateRunning() - wait for first update to run (paused)
+//	2. Unpause() - first update continues (but we don't know that it's run yet)
+//  3. WaitForUpdateRunning() - 1st update has finished, 2nd is running (paused)
+
+func MakeCountingUpdater(p *int, i time.Duration, a bool) snapshot.Updater {
+	updater := &CountingUpdater{pointer: p, interval: i, pause: a}
+	if a {
+		updater.inProg.Lock()
+		updater.wg.Add(1)
+	}
+	return updater
+}
+
+type CountingUpdater struct {
+	pointer  *int
+	interval time.Duration
+	pause    bool
+	wg       sync.WaitGroup
+	crit     sync.Mutex // critical section, locked while update is running including pause
+	inProg   sync.Mutex // locked while we are NOT running, grabbing this means an update started
+}
+
+func (c *CountingUpdater) Update() error {
+	if c.pause {
+		c.crit.Lock()
+		c.inProg.Unlock()
+		c.wg.Wait()
+	}
+
+	*c.pointer += 1
+
+	if c.pause {
+		c.wg.Add(1)
+		c.inProg.Unlock()
+		c.crit.Unlock()
+	}
+	return nil
+}
+
+func (c *CountingUpdater) UpdateInterval() time.Duration {
+	return c.interval
+}
+
+// Not part of interface. If CountingUpdater was created without pause, no effect
+func (c *CountingUpdater) Unpause() {
+	if c.pause {
+		c.wg.Done()
+		c.inProg.Lock()
+	}
+}
+
+func (c *CountingUpdater) WaitForUpdateRunning() {
+	if c.pause {
+		c.inProg.Lock()
+	}
+}


### PR DESCRIPTION
This adds a mechanism for updating underlying repos.  Updates are synchronized between task runs, which are handled by the Controller.  The QueueController is extended to manage updates between runs.

Controllers are exposed to repos via Filers, so an Updater interface has been added to Filer, and wired down through gitdb as RepoUpdater (paired with existing RepoIniter).

In-practice implementation for closed source is added in https://phabricator.twitter.biz/D57159 (for now, golang impl only)