### PR TITLE
Fix worker panic and add timeout for git commands

### DIFF
--- a/common/stats/stats.go
+++ b/common/stats/stats.go
@@ -30,8 +30,7 @@ import (
 // For testing.
 var Time StatsTime = DefaultStatsTime()
 
-var StatReportIntvl time.Duration = 500 *time.Millisecond
-
+var StatReportIntvl time.Duration = 500 * time.Millisecond
 
 // Stats users can either reference this global receiver or construct their own.
 var CurrentStatsReceiver StatsReceiver = NilStatsReceiver()

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -173,7 +173,7 @@ func (c *QueueController) Run(cmd *runner.Command) (runner.RunStatus, error) {
 	resultCh := make(chan result)
 	c.reqCh <- runReq{cmd, resultCh}
 	result := <-resultCh
-	return result.st, result.err // TODO returning runner.RunStatus{} - empty??????? w/ an error
+	return result.st, result.err
 }
 
 func (c *QueueController) enqueue(cmd *runner.Command) (runner.RunStatus, error) {

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -322,7 +322,6 @@ func (c *QueueController) runAndWatch(cmdID cmdAndID) chan runner.RunStatus {
 	c.runningAbort = abortCh
 	c.runningID = cmdID.id
 	c.runningCmd = cmdID.cmd
-	// TODO never returned from fetch origin.
 	go func() {
 		for st := range statusUpdateCh {
 			log.Debugf("Queue pulled result:%+v, jobID:%s taskID=%s runID=%s\n",

--- a/snapshot/git/gitdb/checkout.go
+++ b/snapshot/git/gitdb/checkout.go
@@ -87,16 +87,16 @@ func (db *DB) checkoutFSSnapshot(sha string) (path string, err error) {
 
 	extraEnv := []string{"GIT_INDEX_FILE=" + indexFilename, "GIT_WORK_TREE=" + coDir.Dir}
 
-	cmd := db.dataRepo.Command("read-tree", sha)
+	cmd, cancel := db.dataRepo.Command("read-tree", sha)
 	cmd.Env = append(cmd.Env, extraEnv...)
-	_, err = db.dataRepo.RunCmd(cmd)
+	_, err = db.dataRepo.RunCmd(cmd, cancel)
 	if err != nil {
 		return "", err
 	}
 
-	cmd = db.dataRepo.Command("checkout-index", "-a")
+	cmd, cancel = db.dataRepo.Command("checkout-index", "-a")
 	cmd.Env = append(cmd.Env, extraEnv...)
-	_, err = db.dataRepo.RunCmd(cmd)
+	_, err = db.dataRepo.RunCmd(cmd, cancel)
 	if err != nil {
 		return "", err
 	}

--- a/snapshot/git/gitdb/create.go
+++ b/snapshot/git/gitdb/create.go
@@ -24,16 +24,16 @@ func (db *DB) ingestDirWithRepo(repo *repo.Repository, index, dir string) (snaps
 
 	// TODO(dbentley): should we use update-index instead of add? Maybe add looks at repo state
 	// (e.g., HEAD) and we should just use the lower-level plumbing command?
-	cmd := repo.Command("add", "--all")
+	cmd, cancel := repo.Command("add", "--all")
 	cmd.Env = env
-	_, err := repo.RunCmd(cmd)
+	_, err := repo.RunCmd(cmd, cancel)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd = repo.Command("write-tree")
+	cmd, cancel = repo.Command("write-tree")
 	cmd.Env = env
-	sha, err := repo.RunCmdSha(cmd)
+	sha, err := repo.RunCmdSha(cmd, cancel)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ func (db *DB) ingestGitWorkingDir(ingestRepo *repo.Repository) (snapshot, error)
 		return nil, err
 	}
 
-	cmd := ingestRepo.Command("commit-tree", "-p", "HEAD", "-m", "__scoot_commit", s.SHA())
-	sha, err := ingestRepo.RunCmdSha(cmd)
+	cmd, cancel := ingestRepo.Command("commit-tree", "-p", "HEAD", "-m", "__scoot_commit", s.SHA())
+	sha, err := ingestRepo.RunCmdSha(cmd, cancel)
 	if err != nil {
 		return nil, err
 	}

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -36,12 +36,12 @@ func MakeServer(
 type StatsCollectInterval time.Duration
 
 type handler struct {
-	stat                 stats.StatsReceiver
-	run                  runner.Service
-	timeLastRpc          time.Time
-	mu                   sync.RWMutex
-	currentCmd           *runner.Command
-	currentRunID         runner.RunID
+	stat         stats.StatsReceiver
+	run          runner.Service
+	timeLastRpc  time.Time
+	mu           sync.RWMutex
+	currentCmd   *runner.Command
+	currentRunID runner.RunID
 }
 
 // Creates a new Handler which combines a runner.Service to do work and a StatsReceiver

--- a/workerapi/server/server_test.go
+++ b/workerapi/server/server_test.go
@@ -46,7 +46,7 @@ func TestInitStats(t *testing.T) {
 
 	initDoneCh <- nil // trigger end of initialization
 
-	time.Sleep(2 * stats.StatReportIntvl + (20 * time.Millisecond))
+	time.Sleep(2*stats.StatReportIntvl + (20 * time.Millisecond))
 	// verify stats after initialization
 	if !stats.StatsOk("validating worker done initing stats ", statsRegistry, t,
 		map[string]stats.Rule{


### PR DESCRIPTION
This fixes https://jira.twitter.biz/browse/DX-2266, which is a straightforward panic bug, and provides a mitigation for https://jira.twitter.biz/browse/DX-2282, which is a more complicated issue - see ticket for details.  The root cause of that issue is hanging git processes which this addresses to a degree.