### PR TITLE
runner/queue - don't dederef nil svcstatus error on startup

### DIFF
--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -182,7 +182,11 @@ func (c *QueueController) enqueue(cmd *runner.Command) (runner.RunStatus, error)
 		svcStatus.Initialized, svcStatus.Error, c.capacity-len(c.queue), c.capacity, c.runningID, cmd.JobID, cmd.TaskID)
 
 	if !svcStatus.Initialized {
-		return runner.RunStatus{Error: QueueInitingMsg}, fmt.Errorf(QueueInitingMsg)
+		errStr := QueueInitingMsg
+		if svcStatus.Error != nil {
+			errStr = svcStatus.Error.Error()
+		}
+		return runner.RunStatus{Error: errStr}, fmt.Errorf(QueueInitingMsg)
 	}
 	if len(c.queue) >= c.capacity {
 		return runner.RunStatus{}, fmt.Errorf(QueueFullMsg)

--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -182,7 +182,7 @@ func (c *QueueController) enqueue(cmd *runner.Command) (runner.RunStatus, error)
 		svcStatus.Initialized, svcStatus.Error, c.capacity-len(c.queue), c.capacity, c.runningID, cmd.JobID, cmd.TaskID)
 
 	if !svcStatus.Initialized {
-		return runner.RunStatus{Error: svcStatus.Error.Error()}, fmt.Errorf(QueueInitingMsg)
+		return runner.RunStatus{Error: QueueInitingMsg}, fmt.Errorf(QueueInitingMsg)
 	}
 	if len(c.queue) >= c.capacity {
 		return runner.RunStatus{}, fmt.Errorf(QueueFullMsg)


### PR DESCRIPTION
Looks straightforward from the log in https://jira.twitter.biz/browse/DX-2297 that svcStatus.Error is nil and was getting dereferenced, although I did not reproduce this.