### PR TITLE
snapshot: Create bundles without object deltas.

### DIFF
--- a/snapshot/cli/cli.go
+++ b/snapshot/cli/cli.go
@@ -276,8 +276,9 @@ func (c *createGitBundleCommand) run(db snapshot.DB, _ *cobra.Command, _ []strin
 	revSha1 := fmt.Sprintf("%x", sha1.Sum([]byte(revData)))
 	bundleFilename := path.Join(td.Dir, fmt.Sprintf("bs-%s.bundle", revSha1))
 
-	if _, err := ingestRepo.Run("-c",
-		"core.packobjectedgesonlyshallow=0",
+	if _, err := ingestRepo.Run(
+		"-c", "core.packobjectedgesonlyshallow=0", // bundling may fail without this on some older git versions.
+		"-c", "pack.depth=0", // don't use object deltas in case the recipient is a shallow clone.
 		"bundle",
 		"create",
 		bundleFilename,

--- a/snapshot/git/gitdb/bundlestore.go
+++ b/snapshot/git/gitdb/bundlestore.go
@@ -152,7 +152,13 @@ func (b *bundlestoreBackend) uploadLocalSnapshot(s *localSnapshot, db *DB) (sn s
 	//
 	// error: pack-objects died
 	// so we pass it, but hope to remove it once the bug is fixed
-	if _, err := db.dataRepo.Run("-c", "core.packobjectedgesonlyshallow=0", "bundle", "create", bundleFilename, revList); err != nil {
+	if _, err := db.dataRepo.Run(
+		"-c", "core.packobjectedgesonlyshallow=0", // bundling may fail without this on some older git versions.
+		"-c", "pack.depth=0", // don't use object deltas in case the recipient is a shallow clone.
+		"bundle",
+		"create",
+		bundleFilename,
+		revList); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The bundles we create may not be ingestible by shallow clones, depending on the changes involved. This is an attempt to generate bundles that don't reference the history of included files and can therefore be successfully ingested by repos with limited history.