### PR TITLE
Defensively abort worker task if it didn't return COMPLETE.

### DIFF
--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -77,6 +77,7 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 	}
 
 	go func() {
+		//FIXME(jschiller): allow aborts/timeouts to cancel the checkout process.
 		if cmd.SnapshotID == "" {
 			//TODO: we don't want this logic to live here, these decisions should be made at a higher level.
 			if len(cmd.Argv) > 0 && cmd.Argv[0] != execers.UseSimExecerArg {

--- a/sched/scheduler/task_runner_test.go
+++ b/sched/scheduler/task_runner_test.go
@@ -275,6 +275,7 @@ func Test_runTaskWithQueryRetry(t *testing.T) {
 	runMock.EXPECT().Run(gomock.Any()).Return(runner.RunStatus{}, nil)
 	runMock.EXPECT().Query(gomock.Any(), gomock.Any()).Return(
 		[]runner.RunStatus{{}}, runner.ServiceStatus{}, queryErr).Times(2)
+	runMock.EXPECT().Abort(gomock.Any())
 
 	tr := get_testTaskRunner(s, runMock, "job1", "task1", sched.GenTask(), true, stats.NilStatsReceiver())
 	tr.runnerRetryTimeout = 3 * time.Millisecond


### PR DESCRIPTION
This fixes the issue where scheduler would exit the run step with in error (namely BADREQUEST) and then continue to send jobs to the same worker which was stuck running the previous command. This isn't comprehensive but Abort() is the only mechanism we currently have to clean up a worker.