### PR TITLE
Treat most worker task failures as a reason to mark the associated node flaky.

### DIFF
--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -244,7 +244,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		}
 		return status
 	case execer.FAILED:
-		return runner.ErrorStatus(id, fmt.Errorf("error execing: %v", st.Error), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
+		// We treat failure here as a bad request since it's more likely a faulty cmd than something we did wrong.
+		return runner.BadRequestStatus(id, fmt.Errorf("error execing: %v", st.Error), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
 	default:
 		return runner.ErrorStatus(id, fmt.Errorf("unexpected exec state: %v", st.State), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
 	}

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -119,7 +119,7 @@ func TestMemCap(t *testing.T) {
 
 	query := runner.Query{
 		AllRuns: true,
-		States:  runner.MaskForState(runner.FAILED),
+		States:  runner.MaskForState(runner.BADREQUEST),
 	}
 	// Travis may be slow, wait a super long time? This may also be necessary due to slow debug output from os_execer? TBD.
 	if runs, _, err := r.Query(query, runner.Wait{Timeout: 5 * time.Second}); err != nil {

--- a/runner/status_rw.go
+++ b/runner/status_rw.go
@@ -59,8 +59,12 @@ func (sm StateMask) String() string {
 }
 
 // Helper Function to create StateMask that matches exactly state
-func MaskForState(state RunState) StateMask {
-	return 1 << uint(state)
+func MaskForState(state ...RunState) StateMask {
+	var mask StateMask
+	for _, s := range state {
+		mask = mask | (1 << uint(s))
+	}
+	return mask
 }
 
 // Query describes a query for RunStatuses.

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -76,12 +76,15 @@ func (r *taskRunner) run() error {
 	completed := (st.State == runner.COMPLETE)
 	if err == nil && !completed {
 		switch st.State {
-		case runner.FAILED:
+		case runner.FAILED, runner.UNKNOWN:
+			// runnerErr can be thrift related, or in this case some other failure that's likely our fault.
 			err = fmt.Errorf(st.Error)
+			taskErr.runnerErr = err
 		default:
+			// resultErr can be (ABORTED,TIMEDOUT,BADREQUEST), which indicates a transient or user-related concern.
 			err = fmt.Errorf(st.State.String())
+			taskErr.resultErr = err
 		}
-		taskErr.resultErr = err
 	}
 
 	// We should write to sagalog if there's no error, or there's an error but the caller won't be retrying.

--- a/scootapi/scoot.thrift
+++ b/scootapi/scoot.thrift
@@ -21,10 +21,10 @@ enum RunStatusState {
   PENDING = 1      # Run scheduled but not yet started.
   RUNNING = 2      # Run is happening.
   COMPLETE = 3     # Succeeded or failed yielding an exit code. Only state with an exit code.
-  FAILED = 4       # Run mechanism failed and run is no longer active. Retry may or may not work.
+  FAILED = 4       # Run mechanism failed and is no longer running. Retry may or may not work.
   ABORTED = 5      # User requested that the run be killed.
   TIMEDOUT = 6     # Run timed out and was killed.
-  BADREQUEST = 7   # Invalid or error'd request. Original worker state not affected. Retry may work after mutation.
+  BADREQUEST = 7   # Invalid or error'd request. Retry may or may not work.
 }
 
 // Note, each worker has its own runId space which is unrelated to any external ids.

--- a/workerapi/worker.thrift
+++ b/workerapi/worker.thrift
@@ -3,10 +3,10 @@ enum Status {
   PENDING = 1      # Run scheduled but not yet started.
   RUNNING = 2      # Run is happening.
   COMPLETE = 3     # Succeeded or failed yielding an exit code. Only state with an exit code.
-  FAILED = 4       # Run mechanism failed and run is no longer active. Retry may or may not work.
+  FAILED = 4       # Run mechanism failed and is no longer running. Retry may or may not work.
   ABORTED = 5      # User requested that the run be killed.
   TIMEDOUT = 6     # Run timed out and was killed.
-  BADREQUEST = 7   # Invalid or error'd request. Original worker state not affected. Retry may work after mutation.
+  BADREQUEST = 7   # Invalid or error'd request. Retry may or may not work.
 }
 
 // Note, each worker has its own runId space which is unrelated to any external ids.


### PR DESCRIPTION
The semantics of FAILED and BADREQUEST weren't working well in the scheduler code where we need to mark nodes as flaky depending on what went wrong. FAILED should mean that we had an internal error and BADREQUEST should mean that the user did something wrong.