### PR TITLE
Schedule long-running tasks first, and fix BADREQUEST handling

### DIFF
--- a/runner/runners/invoke.go
+++ b/runner/runners/invoke.go
@@ -248,9 +248,8 @@ func (inv *Invoker) run(cmd *runner.Command, id runner.RunID, abortCh chan struc
 		}
 		return status
 	case execer.FAILED:
-		// We treat failure here as a bad request since it's more likely a faulty cmd than something we did wrong.
-		return runner.BadRequestStatus(id, fmt.Errorf("error execing: %v", st.Error), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
+		return runner.ErrorStatus(id, fmt.Errorf("error execing: %v", st.Error), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
 	default:
-		return runner.ErrorStatus(id, fmt.Errorf("unexpected exec state: %v", st.State), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
+		return runner.ErrorStatus(id, fmt.Errorf("unexpected exec state: %v", st), runner.LogTags{JobID: cmd.JobID, TaskID: cmd.TaskID})
 	}
 }

--- a/runner/runners/polling.go
+++ b/runner/runners/polling.go
@@ -43,8 +43,7 @@ func (r *PollingStatusQuerier) Query(q runner.Query, wait runner.Wait) ([]runner
 			return nil, service, errors.New("Aborted")
 		default:
 		}
-		st, svc, err := r.QueryNow(q)
-		service = svc
+		st, service, err := r.QueryNow(q)
 		if err != nil || len(st) > 0 {
 			return st, service, err
 		}

--- a/runner/runners/service_test.go
+++ b/runner/runners/service_test.go
@@ -31,7 +31,7 @@ func running() runner.RunStatus {
 }
 
 func failed(errorText string) runner.RunStatus {
-	return runner.ErrorStatus(runner.RunID(""), fmt.Errorf(errorText), t)
+	return runner.FailedStatus(runner.RunID(""), fmt.Errorf(errorText), t)
 }
 
 func aborted() runner.RunStatus {

--- a/runner/runners/single_test.go
+++ b/runner/runners/single_test.go
@@ -119,7 +119,7 @@ func TestMemCap(t *testing.T) {
 
 	query := runner.Query{
 		AllRuns: true,
-		States:  runner.MaskForState(runner.BADREQUEST),
+		States:  runner.MaskForState(runner.FAILED),
 	}
 	// Travis may be slow, wait a super long time? This may also be necessary due to slow debug output from os_execer? TBD.
 	if runs, _, err := r.Query(query, runner.Wait{Timeout: 5 * time.Second}); err != nil {

--- a/runner/status.go
+++ b/runner/status.go
@@ -20,13 +20,13 @@ const (
 
 	// Succeeded or failed yielding an exit code. Only state with an exit code.
 	COMPLETE
-	// Run mechanism failed and run is no longer active. Retry may or may not work.
+	// Run mechanism failed in an expected way and is no longer running.
 	FAILED
 	// User requested that the run be killed.
 	ABORTED
 	// Operation timed out and was killed.
 	TIMEDOUT
-	// Request rejected for reasons unrelated to the user.
+	// Request rejected due to unexpected failure.
 	BADREQUEST
 )
 
@@ -115,7 +115,7 @@ func TimeoutStatus(runID RunID, IDs LogTags) (r RunStatus) {
 	return r
 }
 
-func ErrorStatus(runID RunID, err error, IDs LogTags) (r RunStatus) {
+func FailedStatus(runID RunID, err error, IDs LogTags) (r RunStatus) {
 	r.RunID = runID
 	r.State = FAILED
 	r.Error = err.Error()

--- a/runner/status.go
+++ b/runner/status.go
@@ -31,7 +31,7 @@ const (
 )
 
 func (p RunState) IsDone() bool {
-	return p == COMPLETE || p == FAILED || p == ABORTED || p == TIMEDOUT
+	return p == COMPLETE || p == FAILED || p == ABORTED || p == TIMEDOUT || p == UNKNOWN || p == BADREQUEST
 }
 
 func (p RunState) String() string {

--- a/runner/status.go
+++ b/runner/status.go
@@ -26,7 +26,7 @@ const (
 	ABORTED
 	// Operation timed out and was killed.
 	TIMEDOUT
-	// Invalid or error'd request. Original runner state not affected. Retry may work after mutation.
+	// Request rejected for reasons unrelated to the user.
 	BADREQUEST
 )
 

--- a/sched/generators.go
+++ b/sched/generators.go
@@ -97,8 +97,7 @@ func GenRandomTask(rng *rand.Rand) TaskDefinition {
 		envVarsMap[fmt.Sprintf("env%d", j)] = testhelpers.GenRandomAlphaNumericString(rng)
 	}
 
-	// multiply by second to get a reasonable timeout instead of <1 us (which is too short for the command to succeed)
-	timeout := time.Duration(rng.Int63n(1000)) * time.Second
+	timeout := 10 * time.Second //Arbitrary value to support pausing sim execer tests.
 	cmd := runner.Command{
 		SnapshotID: snapshotId,
 		Argv:       args,

--- a/sched/scheduler/cluster_state.go
+++ b/sched/scheduler/cluster_state.go
@@ -82,7 +82,7 @@ func (ns *nodeState) ready() bool {
 	return ready
 }
 
-// Stars a goroutine loop checking node readiness, waiting 'backoff' time between checks, and exiting if node is fully removed.
+// Starts a goroutine loop checking node readiness, waiting 'backoff' time between checks, and exiting if node is fully removed.
 func (ns *nodeState) startReadyLoop(rfn ReadyFn) {
 	ns.readyCh = make(chan interface{})
 	go func() {
@@ -114,7 +114,7 @@ func newNodeState(node cluster.Node) *nodeState {
 		snapshotId:  "",
 		timeLost:    nilTime,
 		timeFlaky:   nilTime,
-		readyCh:     make(chan interface{}),
+		readyCh:     nil,
 		removedCh:   make(chan interface{}),
 	}
 }
@@ -303,14 +303,20 @@ func (c *clusterState) update(updates []cluster.NodeUpdate) {
 			}
 		} else if ns.timeFlaky != nilTime && now.Sub(ns.timeFlaky) > c.maxFlakyDuration {
 			// This flaky node has been suspended long enough, try adding it back to the healthy node pool.
+			// We process this like a new node, using the startReadyLoop/readyFn if present to reapply any side-effects.
+			//
 			// TimeFlaky should've been the only time* value set at this point, reset it.
 			// SnapshotId must be reset since it's used in taskScheduled() and may be gone from nodeGroups.
 			ns.timeFlaky = nilTime
 			ns.snapshotId = ""
 			if c.readyFn != nil {
+				log.Infof("Reinstating flaky node momentarily: %v (%#v), %s", ns.node.Id(), ns, c.status())
 				ns.startReadyLoop(c.readyFn)
+			} else {
+				log.Infof("Reinstating flaky node now: %v (%#v), %s", ns.node.Id(), ns, c.status())
+				delete(c.suspendedNodes, ns.node.Id())
+				c.nodes[ns.node.Id()] = ns
 			}
-			log.Infof("Reinstating flaky node momentarily: %v (%#v), %s", ns.node.Id(), ns, c.status())
 		}
 	}
 

--- a/sched/scheduler/cluster_state_test.go
+++ b/sched/scheduler/cluster_state_test.go
@@ -304,6 +304,7 @@ func Test_ClusterState_NodeGroups(t *testing.T) {
 	cl.add("node3")
 	time.Sleep(2 * time.Millisecond)
 	cs.updateCluster()
+
 	if _, ok := cs.suspendedNodes["node3"]; ok {
 		t.Fatalf("revived node3 should have been removed from the suspended list")
 	} else if ns, ok := cs.nodes["node3"]; !ok {
@@ -311,16 +312,22 @@ func Test_ClusterState_NodeGroups(t *testing.T) {
 	} else if ns.timeLost != nilTime {
 		t.Fatalf("revived node3 should've been marked not lost")
 	}
-	if _, ok := cs.nodes["node1"]; !ok {
-		t.Fatalf("flaky node1 should have been moved to cs.nodes")
-	} else if _, ok := cs.suspendedNodes["node1"]; ok {
-		t.Fatalf("flaky node1 should have been removed from suspended list")
-	}
+
 	if _, ok := cs.nodes["node2"]; ok {
 		t.Fatalf("lost node2 should not have been moved to cs.nodes")
 	} else if _, ok := cs.suspendedNodes["node2"]; ok {
 		t.Fatalf("lost node2 should have been removed from suspended list")
 	}
+
+	// Reinstating nodes is a two-step process, update the cluster one more time.
+	time.Sleep(2 * time.Millisecond)
+	cs.updateCluster()
+	if _, ok := cs.nodes["node1"]; !ok {
+		t.Fatalf("flaky node1 should have been moved to cs.nodes")
+	} else if _, ok := cs.suspendedNodes["node1"]; ok {
+		t.Fatalf("flaky node1 should have been removed from suspended list")
+	}
+
 }
 
 type testCluster struct {

--- a/sched/scheduler/job_state.go
+++ b/sched/scheduler/job_state.go
@@ -59,7 +59,7 @@ func newJobState(job *sched.Job, saga *saga.Saga, taskDurations map[string]avera
 	}
 
 	for _, taskDef := range job.Def.Tasks {
-		duration := taskDurations[taskDef.TaskID].duration
+		duration := taskDurations[taskDef.TaskID].duration // This is safe since the map value is not a pointer.
 		if duration == 0 {
 			duration = math.MaxInt64 // Set max duration if we don't have the average duration.
 		}

--- a/sched/scheduler/job_state_test.go
+++ b/sched/scheduler/job_state_test.go
@@ -13,7 +13,7 @@ func Test_GetUnscheduledTasks_ReturnsAllUnscheduledTasks(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinator().MakeSaga(job.Id, jobAsBytes)
-	jobState := newJobState(&job, saga)
+	jobState := newJobState(&job, saga, nil)
 
 	tasks := jobState.getUnScheduledTasks()
 
@@ -31,7 +31,7 @@ func Test_NewJobState_PreviousProgress_StartedTasks(t *testing.T) {
 	for _, task := range job.Def.Tasks {
 		saga.StartTask(task.TaskID, nil)
 	}
-	jobState := newJobState(&job, saga)
+	jobState := newJobState(&job, saga, nil)
 
 	tasks := jobState.getUnScheduledTasks()
 	if len(tasks) != len(job.Def.Tasks) {
@@ -49,7 +49,7 @@ func Test_NewJobState_PreviousProgress_CompletedTasks(t *testing.T) {
 		saga.StartTask(task.TaskID, nil)
 		saga.EndTask(task.TaskID, nil)
 	}
-	jobState := newJobState(&job, saga)
+	jobState := newJobState(&job, saga, nil)
 
 	tasks := jobState.getUnScheduledTasks()
 	if len(tasks) != 0 {

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -98,6 +98,7 @@ func (s *SchedulerConfig) GetNodeScaleFactor() float32 {
 	return float32(s.NumConfiguredNodes) / float32(s.SoftMaxSchedulableTasks)
 }
 
+// Used to keep a running average of duration for a specific task.
 type averageDuration struct {
 	count    int64
 	duration time.Duration
@@ -133,7 +134,7 @@ type statefulScheduler struct {
 	clusterState   *clusterState
 	inProgressJobs []*jobState                // ordered list of inprogress jobId to job.
 	requestorMap   map[string][]*jobState     // map of requestor to all its jobs. Default requestor="" is ok.
-	taskDurations  map[string]averageDuration // map of taskId to running average of task duration.
+	taskDurations  map[string]averageDuration // map of taskId to averageDuration (note: we unconditionally dereference this).
 
 	// stats
 	stat stats.StatsReceiver

--- a/sched/scheduler/stateful_scheduler_property_test.go
+++ b/sched/scheduler/stateful_scheduler_property_test.go
@@ -44,7 +44,7 @@ func Test_StatefulScheduler_TasksDistributedEvenly(t *testing.T) {
 	// (1000 tasks/5 workers = average of 200 tasks/node)
 	// TODO(dbentley): lowered to 150 b/c I see an error in Travis where:
 	// TaskCountMap: map[node2:198 node1:209 node4:199 node3:166 node5:205]
-	// This is odd, because they only add up to 977 instead of 100, so 23 are being lost altogether.
+	// This is odd, because they only add up to 977 instead of 1000, so 23 are being lost altogether.
 	for nodeId, taskCount := range taskCountMap {
 		if taskCount < 150 || taskCount > 220 {
 			t.Fatalf(`Tasks were not evenly distributed across nodes.  Expected each node

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -426,8 +426,10 @@ func Test_StatefulScheduler_KillFinishedJob(t *testing.T) {
 	}
 
 	// verify state changed appropriately
-	if s.clusterState.nodes["node1"].runningTask != noTask {
-		t.Errorf("Expected node1 to not have any running tasks")
+	for i := 0; i < 5; i++ {
+		if s.clusterState.nodes[cluster.NodeId(fmt.Sprintf("node%d", i+1))].runningTask != noTask {
+			t.Errorf("Expected nodes to not have any running tasks")
+		}
 	}
 
 	// advance scheduler until job gets marked completed
@@ -445,7 +447,7 @@ func Test_StatefulScheduler_KillFinishedJob(t *testing.T) {
 		}
 	} else {
 		j := s.getJob(jobId)
-		for j == nil {
+		for j != nil {
 			s.step()
 			j = s.getJob(jobId)
 		}

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -183,7 +183,7 @@ func (r *taskRunner) runAndWait() (runner.RunStatus, bool, error) {
 	for {
 		st, end, err = r.queryWithTimeout(id, cmdEndTime, includeRunning)
 		elapsed := elapsedRetryDuration + r.runnerRetryInterval
-		if (err != nil && elapsed >= r.runnerRetryTimeout) || st.State.IsDone() {
+		if (err != nil && elapsed >= r.runnerRetryTimeout) || (err == nil && st.State.IsDone()) {
 			if st.State != runner.COMPLETE {
 				r.runner.Abort(id)
 			}

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -37,6 +37,8 @@ type taskRunner struct {
 
 	abortCh      chan bool        // Primary channel to check for aborts
 	queryAbortCh chan interface{} // Secondary channel to pass to blocking query.
+
+	startTime time.Time
 }
 
 // Return a custom error from run() so the scheduler has more context.

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -78,12 +78,12 @@ func (r *taskRunner) run() error {
 	completed := (st.State == runner.COMPLETE)
 	if err == nil && !completed {
 		switch st.State {
-		case runner.FAILED, runner.UNKNOWN:
-			// runnerErr can be thrift related, or in this case some other failure that's likely our fault.
+		case runner.FAILED, runner.UNKNOWN, runner.BADREQUEST:
+			// runnerErr can be thrift related above, or in this case some other failure that's likely our fault.
 			err = fmt.Errorf(st.Error)
 			taskErr.runnerErr = err
 		default:
-			// resultErr can be (ABORTED,TIMEDOUT,BADREQUEST), which indicates a transient or user-related concern.
+			// resultErr can be (ABORTED,TIMEDOUT), which indicates a transient or user-related concern.
 			err = fmt.Errorf(st.State.String())
 			taskErr.resultErr = err
 		}

--- a/sched/scheduler/task_runner.go
+++ b/sched/scheduler/task_runner.go
@@ -198,6 +198,7 @@ func (r *taskRunner) runAndWait() (runner.RunStatus, bool, error) {
 			// its status, so a watcher can go investigate. Strictly speaking this is optional
 			// in that we've already logged a start task and our only obligation is to log a
 			//corresponding end task.
+			log.Debugf("Update task - jobId: %s, taskId: %s, node: %s, runStatus: %s", r.jobId, r.taskId, r.nodeSt.node, st)
 			r.logTaskStatus(&st, saga.StartTask)
 			includeRunning = false
 		}

--- a/sched/scheduler/task_runner_test.go
+++ b/sched/scheduler/task_runner_test.go
@@ -274,7 +274,7 @@ func Test_runTaskWithQueryRetry(t *testing.T) {
 
 	runMock := runnermock.NewMockService(mockCtrl)
 	queryErr := errors.New("QueryErr")
-	runMock.EXPECT().Run(gomock.Any()).Return(runner.RunStatus{}, nil)
+	runMock.EXPECT().Run(gomock.Any()).Return(runner.RunStatus{State: runner.PENDING}, nil)
 	runMock.EXPECT().Query(gomock.Any(), gomock.Any()).Return(
 		[]runner.RunStatus{{}}, runner.ServiceStatus{}, queryErr).Times(2)
 	runMock.EXPECT().Abort(gomock.Any())

--- a/sched/scheduler/task_scheduler_test.go
+++ b/sched/scheduler/task_scheduler_test.go
@@ -20,7 +20,7 @@ func Test_TaskAssignment_NoNodesAvailable(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinator().MakeSaga(job.Id, jobAsBytes)
-	js := newJobState(&job, saga)
+	js := newJobState(&job, saga, nil)
 
 	// create a test cluster with no nodes
 	testCluster := makeTestCluster()
@@ -50,7 +50,7 @@ func Test_TaskAssignments_TasksScheduled(t *testing.T) {
 	jobAsBytes, _ := job.Serialize()
 
 	saga, _ := sagalogs.MakeInMemorySagaCoordinator().MakeSaga(job.Id, jobAsBytes)
-	js := newJobState(&job, saga)
+	js := newJobState(&job, saga, nil)
 	req := map[string][]*jobState{"": []*jobState{js}}
 
 	// create a test cluster with no nodes

--- a/scootapi/locate.go
+++ b/scootapi/locate.go
@@ -17,7 +17,8 @@ import (
 
 // Get the path of the file containing the address for scootapi to use
 func GetScootapiAddrPath() string {
-	return path.Join(os.Getenv("HOME"), ".cloudscootaddr")
+	optionalId := os.Getenv("SCOOT_ID") // Used to connect to a different set of scoot processes.
+	return path.Join(os.Getenv("HOME"), ".cloudscootaddr"+optionalId)
 }
 
 // Get the scootapi address (as host:port)

--- a/scootapi/locate.go
+++ b/scootapi/locate.go
@@ -11,6 +11,9 @@ import (
 // Where is Cloud Scoot running?
 // We store the answer (as host:port\nhost:port) in ~/.cloudscootaddr
 // There are two lines: first is the sched thrift addr, second is the bundlestore http addr.
+// The user may set SCOOT_ID=<ArbitraryId> to refer to a Scoot Cloud address other than the default.
+//  This is useful, for example, in dev testing of multiple *remote* Cloud Scoot instances.
+//
 // TODO: this will eventually store only the thrift addr and http addr
 //       for a single instance of apiserver, though several may be running.
 // TODO: can we get rid of this and exclusively rely on a Fetcher to find instances?

--- a/scootapi/scoot.thrift
+++ b/scootapi/scoot.thrift
@@ -21,10 +21,10 @@ enum RunStatusState {
   PENDING = 1      # Run scheduled but not yet started.
   RUNNING = 2      # Run is happening.
   COMPLETE = 3     # Succeeded or failed yielding an exit code. Only state with an exit code.
-  FAILED = 4       # Run mechanism failed and is no longer running. Retry may or may not work.
+  FAILED = 4       # Run mechanism failed and is no longer running.
   ABORTED = 5      # User requested that the run be killed.
   TIMEDOUT = 6     # Run timed out and was killed.
-  BADREQUEST = 7   # Invalid or error'd request. Retry may or may not work.
+  BADREQUEST = 7   # Request rejected for reasons unrelated to the user.
 }
 
 // Note, each worker has its own runId space which is unrelated to any external ids.

--- a/scootapi/scoot.thrift
+++ b/scootapi/scoot.thrift
@@ -21,10 +21,10 @@ enum RunStatusState {
   PENDING = 1      # Run scheduled but not yet started.
   RUNNING = 2      # Run is happening.
   COMPLETE = 3     # Succeeded or failed yielding an exit code. Only state with an exit code.
-  FAILED = 4       # Run mechanism failed and is no longer running.
+  FAILED = 4       # Run mechanism failed in an expected way and is no longer running.
   ABORTED = 5      # User requested that the run be killed.
   TIMEDOUT = 6     # Run timed out and was killed.
-  BADREQUEST = 7   # Request rejected for reasons unrelated to the user.
+  BADREQUEST = 7   # Request rejected due to unexpected failure.
 }
 
 // Note, each worker has its own runId space which is unrelated to any external ids.

--- a/workerapi/server/server.go
+++ b/workerapi/server/server.go
@@ -158,7 +158,7 @@ func (h *handler) Run(cmd *worker.RunCommand) (*worker.RunStatus, error) {
 		status, _, err = h.run.Status(h.currentRunID)
 	}
 	if err != nil {
-		// Set invalid status and nil err to indicate handleable domain err.
+		// Set invalid status and nil err to indicate handleable internal err.
 		status.Error = err.Error()
 		status.State = runner.BADREQUEST
 	} else {

--- a/workerapi/worker.thrift
+++ b/workerapi/worker.thrift
@@ -3,10 +3,10 @@ enum Status {
   PENDING = 1      # Run scheduled but not yet started.
   RUNNING = 2      # Run is happening.
   COMPLETE = 3     # Succeeded or failed yielding an exit code. Only state with an exit code.
-  FAILED = 4       # Run mechanism failed and is no longer running. Retry may or may not work.
+  FAILED = 4       # Run mechanism failed and is no longer running.
   ABORTED = 5      # User requested that the run be killed.
   TIMEDOUT = 6     # Run timed out and was killed.
-  BADREQUEST = 7   # Invalid or error'd request. Retry may or may not work.
+  BADREQUEST = 7   # Request rejected for reasons unrelated to the user.
 }
 
 // Note, each worker has its own runId space which is unrelated to any external ids.

--- a/workerapi/worker.thrift
+++ b/workerapi/worker.thrift
@@ -3,10 +3,10 @@ enum Status {
   PENDING = 1      # Run scheduled but not yet started.
   RUNNING = 2      # Run is happening.
   COMPLETE = 3     # Succeeded or failed yielding an exit code. Only state with an exit code.
-  FAILED = 4       # Run mechanism failed and is no longer running.
+  FAILED = 4       # Run mechanism failed in an expected way and is no longer running.
   ABORTED = 5      # User requested that the run be killed.
   TIMEDOUT = 6     # Run timed out and was killed.
-  BADREQUEST = 7   # Request rejected for reasons unrelated to the user.
+  BADREQUEST = 7   # Request rejected due to unexpected failure.
 }
 
 // Note, each worker has its own runId space which is unrelated to any external ids.


### PR DESCRIPTION
Scheduling tasks by historical run duration is a good-enough optimization until we have clients that can do efficient DAG-based scheduling.

Also fixes mishandling of BADREQUEST after a run request from scheduler -> worker.