### PR TITLE
Increase min number of nodes for higher priority jobs.

### DIFF
--- a/config/scootconfig/scheduler_config_modules.go
+++ b/config/scootconfig/scheduler_config_modules.go
@@ -27,6 +27,8 @@ const DefaultReadyFnBackoff = 5 * time.Second
 // RecoverJobsOnStartup - if true, the scheduler recovers active sagas,
 //             from the sagalog, and restarts them.
 // DefaultTaskTimeout - default timeout for tasks, human readable ex: "30m"
+//
+// See scheduler.SchedulerConfig for comments on the remaining fields.
 type StatefulSchedulerConfig struct {
 	Type                    string
 	MaxRetriesPerTask       int

--- a/config/scootconfig/scheduler_config_modules.go
+++ b/config/scootconfig/scheduler_config_modules.go
@@ -38,9 +38,7 @@ type StatefulSchedulerConfig struct {
 	TaskTimeoutOverhead     string
 	MaxRequestors           int
 	MaxJobsPerRequestor     int
-	NumConfiguredNodes      int
 	SoftMaxSchedulableTasks int
-	LargeJobSoftMaxNodes    int
 }
 
 func (c *StatefulSchedulerConfig) Install(bag *ice.MagicBag) {
@@ -75,8 +73,6 @@ func (c *StatefulSchedulerConfig) Create() (scheduler.SchedulerConfig, error) {
 		ReadyFnBackoff:          DefaultReadyFnBackoff,
 		MaxRequestors:           c.MaxRequestors,
 		MaxJobsPerRequestor:     c.MaxJobsPerRequestor,
-		NumConfiguredNodes:      c.NumConfiguredNodes,
 		SoftMaxSchedulableTasks: c.SoftMaxSchedulableTasks,
-		LargeJobSoftMaxNodes:    c.LargeJobSoftMaxNodes,
 	}, nil
 }

--- a/sched/scheduler/doc.go
+++ b/sched/scheduler/doc.go
@@ -1,0 +1,54 @@
+/*
+package scheduler provides StatefulScheduler which distributes tasks to a cluster of nodes.
+
+* Concepts *
+JobPriority:
+  0 Default, queue new runs until all higher priority jobs are satisfied
+  1 Run ahead of priority=0, but otherwise treated the same as priority=0
+  2 Run ahead of priority<=1, killing youngest lower priority tasks if no nodes are free (up to MinRunningNodesForGivenJob)
+  3 Run ahead of priority<=2, acquiring as many nodes as possible, killing youngest lower priority tasks if no nodes are free
+Note: Lower priority jobs are given a chance once MinRunningNodesForGivenJob for higher priority jobs is satisfied.
+      However, priority 3 jobs are greedy and have no minimum number of nodes whereupon they defer to lower priorities.
+
+SoftMaxSchedulableTasks:
+  This limit helps determine nodes per job but doesn’t actually result in scheduler backpressure.
+
+NumRunningNodes:
+  The total number of nodes in the cluster which are capable of running a task, even if currently busy.
+
+NodeScaleFactor:
+  Used to calculate how many tasks a job can run without adversely affecting other jobs.
+  We account for job priority by increasing the scale factor by an appropriate percentage.
+  = (NumRunningNodes / SoftMaxSchedulableTasks) * (1 + Job.Priority * SomeMultiplier)
+
+MinRunningNodesForGivenJob:
+  = ceil(min(NumFreeNodes, Job.NumRequestedTasks * NodeScaleFactor, Job.NumRemainingTasks))
+
+MaxJobsPerRequestor,  MaxRequestors:
+  These limits are somewhat arbitrary and are only meant to prevent spamming, not to ensure fairness.
+  Scheduler will apply backpressure if we hit these limits.
+
+* Logic *
+Schedule Loop:
+Group new job requests with existing jobs sharing the same RequestTag
+Add remaining unmatched requests to the jobs queue but limit number of jobs per Requestor
+
+For Job in Jobs.Priority3,
+ Select NumAssignedNodes=min(Job.NumRemainingTasks, NumFreeNodes + NumKillableNodes w/ level<3)
+For Job in Jobs.Priority2:
+ Select NumAssignedNodes=min(Job.NumRemainingTasks, MinRunningNodesForGivenJob, NumFreeNodes + NumKillableNodes w/ level<2)
+For Job in Jobs.Priority1:
+ Select NumAssignedNodes=min(Job.NumRemainingTasks, MinRunningNodesForGivenJob, NumFreeNodes)
+For Job in Jobs.Priority0:
+ Select NumAssignedNodes=min(Job.NumRemainingTasks, MinRunningNodesForGivenJob, NumFreeNodes)
+
+Select Node Preference:
+   Free nodes with the same SnapshotID as the given task, where the last ran task is different.
+   Free nodes with the same SnapshotID as the given task.
+   Free nodes not related to any current job.
+   Any free node.
+   If priority >= 2: busy node with smallest run duration from priority0 tasks.
+   If priority >= 2: busy node with smallest run duration from priority1 tasks.
+   If priority >= 3: busy node with smallest run duration from priority2 tasks.
+*/
+package scheduler

--- a/sched/scheduler/stateful_scheduler_test.go
+++ b/sched/scheduler/stateful_scheduler_test.go
@@ -518,6 +518,27 @@ func Test_StatefulScheduler_KillNotStartedJob(t *testing.T) {
 	sendKillRequest(jobId1, s)
 }
 
+func Test_StatefulScheduler_NodeScaleFactor(t *testing.T) {
+	NodeScaleAdjustment = .5 // Setting this global setting explicitly for consistency.
+	s := &SchedulerConfig{SoftMaxSchedulableTasks: 1000}
+	numNodes := 20
+	numTasks := float32(1)
+	if n := ceil(numTasks * s.GetNodeScaleFactor(numNodes, 0)); n != 1 {
+		t.Errorf("Expected 1, got %d", n)
+	}
+
+	numTasks = float32(100)
+	if n := ceil(numTasks * s.GetNodeScaleFactor(numNodes, 0)); n != 2 {
+		t.Errorf("Expected 2, got %d", n)
+	}
+	if n := ceil(numTasks * s.GetNodeScaleFactor(numNodes, 1)); n != 3 {
+		t.Errorf("Expected 3, got %d", n)
+	}
+	if n := ceil(numTasks * s.GetNodeScaleFactor(numNodes, 2)); n != 4 {
+		t.Errorf("Expected 4, got %d", n)
+	}
+}
+
 func allTasksInState(jobName string, jobId string, s *statefulScheduler, status sched.Status) bool {
 	for _, task := range s.getJob(jobId).Tasks {
 		if task.Status != status {

--- a/sched/scheduler/task_scheduler_test.go
+++ b/sched/scheduler/task_scheduler_test.go
@@ -158,9 +158,7 @@ func Test_TaskAssignments_RequestorBatching(t *testing.T) {
 
 	req := map[string][]*jobState{"": js}
 	config := &SchedulerConfig{
-		NumConfiguredNodes:      len(nodes), // GetNodeScaleFactor() is (NumConfiguredNodes / SoftMaxSchedulableTasks)
-		SoftMaxSchedulableTasks: 10,         // We want numTasks*GetNodeScaleFactor()==3 to define a specific order for scheduling.
-		LargeJobSoftMaxNodes:    DefaultLargeJobSoftMaxNodes,
+		SoftMaxSchedulableTasks: 10, // We want numTasks*GetNodeScaleFactor()==3 to define a specific order for scheduling.
 	}
 
 	assignments, _ := getTaskAssignments(cs, js, req, config, nil)
@@ -293,9 +291,7 @@ func Test_TaskAssignments_PriorityStages(t *testing.T) {
 
 	req := map[string][]*jobState{"": js}
 	config := &SchedulerConfig{
-		NumConfiguredNodes:      len(nodes), // GetNodeScaleFactor() is (NumConfiguredNodes / SoftMaxSchedulableTasks)
-		SoftMaxSchedulableTasks: 50,         // We want numTasks*GetNodeScaleFactor()==2 to define a specific order for scheduling.
-		LargeJobSoftMaxNodes:    DefaultLargeJobSoftMaxNodes,
+		SoftMaxSchedulableTasks: 50, // We want numTasks*GetNodeScaleFactor()==2 to define a specific order for scheduling.
 	}
 
 	// Check for all 10 P3 tasks
@@ -315,7 +311,7 @@ func Test_TaskAssignments_PriorityStages(t *testing.T) {
 	}
 
 	// Check for 5 P2, 3 P1, and 2 P0 tasks
-	NodeScaleAdjustment = 0
+	NodeScaleAdjustment = 0 //Reset this global setting to simplify testing here.
 	assignments, _ = getTaskAssignments(cs, js, req, config, nil)
 	if len(assignments) != 10 {
 		t.Fatalf("Expected ten tasks to be assigned, got %v", len(assignments))

--- a/sched/scheduler/task_scheduler_test.go
+++ b/sched/scheduler/task_scheduler_test.go
@@ -315,6 +315,7 @@ func Test_TaskAssignments_PriorityStages(t *testing.T) {
 	}
 
 	// Check for 5 P2, 3 P1, and 2 P0 tasks
+	NodeScaleAdjustment = 0
 	assignments, _ = getTaskAssignments(cs, js, req, config, nil)
 	if len(assignments) != 10 {
 		t.Fatalf("Expected ten tasks to be assigned, got %v", len(assignments))


### PR DESCRIPTION
Increase min number of nodes for higher priority jobs.
Allow new related jobs to jump the queue.
Clearer scheduler config defaults.