### PR TITLE
scoot/runners - make StatusManager and Queue messages Info

### DIFF
--- a/runner/runners/queue.go
+++ b/runner/runners/queue.go
@@ -328,7 +328,7 @@ func (c *QueueController) runAndWatch(cmdID cmdAndID) chan runner.RunStatus {
 	c.runningCmd = cmdID.cmd
 	go func() {
 		for st := range statusUpdateCh {
-			log.Debugf("Queue pulled result:%+v, jobID:%s taskID=%s runID=%s\n",
+			log.Infof("Queue pulled result:%+v, jobID:%s taskID=%s runID=%s\n",
 				cmdID.cmd.JobID, cmdID.cmd.TaskID, cmdID.id, st)
 			c.statusManager.Update(st)
 			if st.State.IsDone() {

--- a/runner/runners/status_manager.go
+++ b/runner/runners/status_manager.go
@@ -64,7 +64,7 @@ func (s *StatusManager) UpdateService(svcStatus runner.ServiceStatus) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Debugf("StatusManager updating svc:%v", svcStatus)
+	log.Infof("StatusManager updating svc:%v", svcStatus)
 	s.svcStatus = svcStatus
 	return nil
 }
@@ -92,7 +92,7 @@ func (s *StatusManager) Update(newStatus runner.RunStatus) error {
 		newStatus.StderrRef = oldStatus.StderrRef
 	}
 
-	log.Debugf("StatusManager is holding status --- JobID:%s, TaskID:%s, RunID:%s, Status:%s",
+	log.Infof("StatusManager is holding status --- JobID:%s, TaskID:%s, RunID:%s, Status:%s",
 		newStatus.JobID, newStatus.TaskID, newStatus.RunID, newStatus.State)
 	s.runs[newStatus.RunID] = newStatus
 


### PR DESCRIPTION
This is a "feeler" diff for an adjustment to worker logs. The motivations are:
1. make more useful information about tasks available via loglens by promoting them to 'info' level.
2. Get rid of noise in worker by switching over to info level (this will be a closed-source diff).
By promoting these logs to info, the main thing we would ditch from debug level on the worker are the ps output messages from os/os_execer.go's logs, that make it very hard to follow the worker log.

On a worker that's been up ~4 days, the logs promoted here amounted to 500 or so per day average, which I don't think will be an issue for log lens.

Note: if we do this, planning on leaving devel & staging at debug level.