### PR TITLE
Disabled priority>1 since it's not tested.

### DIFF
--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -55,7 +55,7 @@ const DefaultMaxJobsPerRequestor = 100
 const DefaultSoftMaxSchedulableTasks = 1000
 
 // Increase the NodeScaleFactor by a percentage defined by 1 + (Priority * NodeScaleAdjustment)
-var NodeScaleAdjustment = .5
+var NodeScaleAdjustment = 1
 
 // Scheduler Config variables read at initialization
 // MaxRetriesPerTask - the number of times to retry a failing task before

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -55,7 +55,7 @@ const DefaultMaxJobsPerRequestor = 100
 const DefaultSoftMaxSchedulableTasks = 1000
 
 // Increase the NodeScaleFactor by a percentage defined by 1 + (Priority * NodeScaleAdjustment)
-var NodeScaleAdjustment = 1
+var NodeScaleAdjustment = 1.0
 
 // Scheduler Config variables read at initialization
 // MaxRetriesPerTask - the number of times to retry a failing task before

--- a/sched/scheduler/stateful_scheduler.go
+++ b/sched/scheduler/stateful_scheduler.go
@@ -407,6 +407,12 @@ checkLoop:
 								js.Job.Def.Priority, m.jobDef.Requestor, m.jobDef.Tag, m.jobDef.Basis, m.jobDef.Priority, len(m.jobDef.Tasks))
 						}
 					}
+				} else if checkJobMsg.jobDef.Priority > sched.P1 {
+					// Priorities greater than 1 are disabled in job_state.go.
+					jd := checkJobMsg.jobDef
+					log.Infof("Overriding job priority %d to respect max priority of 1 (higher priority is untested and disabled)"+
+						"Requestor:%s, Tag:%s, Basis:%s, Priority:%d, numTasks: %d",
+						jd.Priority, jd.Requestor, jd.Tag, jd.Basis, jd.Priority, len(jd.Tasks))
 				}
 			}
 			checkJobMsg.resultCh <- err

--- a/sched/scheduler/task_scheduler.go
+++ b/sched/scheduler/task_scheduler.go
@@ -155,7 +155,7 @@ Loop:
 					numTasks += len(j.Tasks)
 					numCompleted += j.TasksCompleted
 					numRunning += j.TasksRunning
-					if j.Job.Def.Priority > p {
+					if j.InsertionPriority > p {
 						unsched = append(j.getUnScheduledTasks(), unsched...)
 					} else {
 						unsched = append(unsched, j.getUnScheduledTasks()...)


### PR DESCRIPTION
We were seeing a panic in task_scheduler kill logic. This disables untested priorities >1 but keeps the job insertion order logic, albeit in a hacky way that should eventually be replaced by a protocol change.